### PR TITLE
Chip 컴포넌트 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,11 @@
 @tailwind utilities;
 
 @layer base {
+  @font-face {
+    font-family: 'Pretendard';
+    src: url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/static/pretendard.css');
+  }
+
   :root {
     --bgColor: rgb(255, 255, 255);
     --slate9: rgb(16, 23, 41);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,6 @@
 import { Providers, ThemeButton } from '@/components'
-import { cls } from '@/utils'
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import './globals.css'
-
-const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -18,7 +14,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body className={cls('bg-bgColor', inter.className)}>
+      <body className="bg-bgColor">
         <Providers>
           <div className="mx-auto w-full max-w-[500px]">{children}</div>
           <ThemeButton />

--- a/src/components/common/Chip/Chip.tsx
+++ b/src/components/common/Chip/Chip.tsx
@@ -1,0 +1,31 @@
+import { cls } from '@/utils'
+import { COLORS } from './constants'
+
+export type ChipColors =
+  | 'emerald'
+  | 'red'
+  | 'yellow'
+  | 'blue'
+  | 'indigo'
+  | 'purple'
+  | 'pink'
+  | 'gray'
+
+export interface ChipProps {
+  label: string
+  color?: ChipColors
+}
+
+const Chip = ({ label, color = 'emerald' }: ChipProps) => {
+  return (
+    <div
+      className={cls(
+        'inline-flex rounded-xl px-2.5 py-1 text-center text-xs font-medium',
+        COLORS[color],
+      )}>
+      {label}
+    </div>
+  )
+}
+
+export default Chip

--- a/src/components/common/Chip/constants/index.ts
+++ b/src/components/common/Chip/constants/index.ts
@@ -1,0 +1,10 @@
+export const COLORS = {
+  emerald: 'bg-emerald-200 text-emerald-900',
+  red: 'bg-red-200 text-red-900',
+  yellow: 'bg-yellow-200 text-yellow-900',
+  blue: 'bg-blue-200 text-blue-900',
+  indigo: 'bg-indigo-200 text-indigo-900',
+  purple: 'bg-purple-200 text-purple-900',
+  pink: 'bg-pink-200 text-pink-900',
+  gray: 'bg-gray-200 text-gray-900',
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export { default as Providers } from './Providers/providers'
 export { default as ThemeButton } from './ThemeButton/themeButton'
+export { default as Chip } from './common/Chip/Chip'

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss'
+import { fontFamily } from 'tailwindcss/defaultTheme'
 
 const config: Config = {
   content: [
@@ -44,6 +45,9 @@ const config: Config = {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic':
           'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
+      },
+      fontFamily: {
+        sans: ['"Pretendard"', ...fontFamily.sans],
       },
     },
   },


### PR DESCRIPTION
## 📑 이슈 번호
- close #4 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- Pretendard 폰트 적용
- Chip 컴포넌트 구현
<img width="72" alt="LinkHub-FE_chip-component" src="https://github.com/Team-TenTen/LinkHub-FE/assets/49032882/49a5d757-3f0f-48fb-8c7d-195105dea49a">

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### Chip Props
```typescript
interface ChipProps {
  label: string // 라벨 텍스트
  color?: ChipColors // 색상 (default: 'emerald')
}
```

### Chip Colors 타입 정의
```typescript
type ChipColors = // Tailwind 색상 이름과 동일합니다.
  | 'emerald'
  | 'red'
  | 'yellow'
  | 'blue'
  | 'indigo'
  | 'purple'
  | 'pink'
  | 'gray'
```

### 사용 예시
```javascript
<Chip label="Tag" />
<Chip
  label="Tag"
  color="red"
/>
```