### PR TITLE
로그인 페이지 구현

### DIFF
--- a/src/app/(routes)/login/page.tsx
+++ b/src/app/(routes)/login/page.tsx
@@ -1,5 +1,11 @@
+import Login from '@/components/Login/Login'
+
 const LoginPage = () => {
-  return <></>
+  return (
+    <div>
+      <Login />
+    </div>
+  )
 }
 
 export default LoginPage

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { LinkIcon } from '@heroicons/react/20/solid'
+import { ChatBubbleOvalLeftIcon } from '@heroicons/react/24/solid'
+import Button from '../common/Button/Button'
+import { useLogin } from './hooks/useLogin'
+
+const Login = () => {
+  const { loginKakao } = useLogin()
+
+  //Todo: 카카오 로그인 토큰을 받아서 토큰이 db에 존재하면 로그인, 존재하지 않으면 회원가입
+
+  return (
+    <div className="flex h-screen translate-y-[-9%] flex-col justify-center gap-10 pl-4 pr-4">
+      <div className="flex flex-col items-center justify-center gap-3">
+        <div>
+          <LinkIcon className="h-10 w-10 text-emerald5" />
+        </div>
+        <div className="text-4xl font-normal leading-10 text-emerald5">
+          LinkHub
+        </div>
+      </div>
+      <Button
+        type="button"
+        className="button button-md flex w-full items-center justify-center border-none bg-yellow-400 px-3 py-2.5">
+        <ChatBubbleOvalLeftIcon className="h-6 w-6 text-gray-800" />
+        <div
+          onClick={() => loginKakao()}
+          className="text-sm font-bold text-gray-800">
+          카카오로 시작하기
+        </div>
+      </Button>
+    </div>
+  )
+}
+
+export default Login

--- a/src/components/Login/hooks/useLogin.ts
+++ b/src/components/Login/hooks/useLogin.ts
@@ -1,0 +1,9 @@
+const useLogin = () => {
+  const loginKakao = () => {
+    console.log('카카오 로그인 로직')
+  }
+
+  return { loginKakao }
+}
+
+export { useLogin }


### PR DESCRIPTION
## 📑 이슈 번호
Closes #54 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
### 로그인 페이지를 구현했습니다.
![image](https://github.com/Team-TenTen/LinkHub-FE/assets/66124037/a61b821b-2d68-4348-bdc7-84f0b42c8da8)

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
- Todo: 카카오 로그인 토큰을 받아서 토큰이 db에 존재하면 로그인, 존재하지 않으면 회원가입페이지로 이동

### 수정중...