### PR TITLE
회원가입 페이지 구현

### DIFF
--- a/src/app/(routes)/register/page.tsx
+++ b/src/app/(routes)/register/page.tsx
@@ -1,5 +1,11 @@
+import UserInfoForm from '@/components/UserInfoForm/UserInfoForm'
+
 const RegisterPage = () => {
-  return <></>
+  return (
+    <div>
+      <UserInfoForm />
+    </div>
+  )
 }
 
 export default RegisterPage

--- a/src/components/UserInfoForm/UserInfoForm.tsx
+++ b/src/components/UserInfoForm/UserInfoForm.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { Avatar, CategoryList, Input } from '@/components'
+import { cls } from '@/utils'
+import { CheckIcon } from '@heroicons/react/24/solid'
+import Button from '../common/Button/Button'
+import useToggle from '../common/Toggle/hooks/useToggle'
+import { useRegister } from './hooks/useRegister'
+
+interface FormValues {
+  nickName: string
+  introduce: string
+  email: string
+  category: string
+  newsLetter: boolean
+  emailAuth: boolean
+}
+
+const UserInfoForm = () => {
+  const [isEmailAuthOpen, setIsEmailAuthOpen] = useState(false)
+  const [checked, toggle] = useToggle(false)
+  const { registerLinkHub } = useRegister()
+
+  const emailRegex =
+    /^[a-zA-Z0-9.!#$%&'*+/=?&_`{|}~-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-]/
+
+  const {
+    register,
+    setValue,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues: {
+      category: '엔터테인먼트•예술',
+      newsLetter: false,
+      emailAuth: false,
+    },
+  })
+
+  const handleClickCheckButton = () => {
+    toggle()
+    setValue('newsLetter', !checked)
+  }
+
+  return (
+    <form
+      className="flex flex-col gap-3 px-4 pt-8"
+      onSubmit={handleSubmit((data) => {
+        registerLinkHub(data)
+      })}>
+      <div className="flex justify-center">
+        <Avatar
+          src="/duck.jpg"
+          width={80}
+          height={80}
+          alt="프로필"
+        />
+      </div>
+      <div>
+        <Input
+          {...register('nickName', {
+            required: '닉네임을 입력해 주세요',
+          })}
+          label="닉네임"
+          placeholder="Nickname"
+          validation={errors.nickName?.message}
+        />
+      </div>
+      <div>
+        <Input
+          {...register('introduce')}
+          label="한줄 소개"
+          placeholder="Introduce"
+        />
+      </div>
+      <div>
+        <Input
+          {...register('email', {
+            required: '이메일을 입력해 주세요',
+            pattern: emailRegex,
+          })}
+          validation={
+            errors.email?.type === 'pattern'
+              ? '이메일 양식에 맞게 입력해 주세요'
+              : errors.email?.message
+          }
+          label="이메일"
+          placeholder="Email"
+          inputButton
+          buttonText="인증번호 전송"
+          buttonColor="gray"
+          onButtonClick={() => setIsEmailAuthOpen(true)}
+        />
+      </div>
+      {isEmailAuthOpen && (
+        <div>
+          <Input
+            label="이메일 인증"
+            placeholder="인증번호를 입력해 주세요"
+            inputButton
+            buttonText="인증번호 확인"
+            buttonColor="gray"
+            onButtonClick={() => {}}
+          />
+        </div>
+      )}
+      <div className="flex flex-col">
+        <div className="py-2 text-sm font-semibold text-gray9">
+          관심 카테고리
+        </div>
+        <CategoryList
+          type="default"
+          horizontal={false}
+          onChange={(e) => setValue('category', e?.currentTarget.value || '')}
+        />
+      </div>
+      <div className="flex items-center gap-3 py-2">
+        <div>관심 카테고리로 뉴스레터 받아보기 동의하시겠습니까?</div>
+        <label>
+          <input
+            type="checkBox"
+            hidden
+            onChange={handleClickCheckButton}
+          />
+          <CheckIcon
+            className={cls(
+              'h-5 w-5 rounded-sm text-white',
+              checked ? 'bg-emerald5 ' : 'bg-gray9',
+            )}
+          />
+        </label>
+      </div>
+      <div className="py-6">
+        <Button
+          type="submit"
+          className="button button-lg button-gray px-4 py-2.5">
+          가입하기
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+export default UserInfoForm

--- a/src/components/UserInfoForm/hooks/useRegister.ts
+++ b/src/components/UserInfoForm/hooks/useRegister.ts
@@ -4,7 +4,6 @@ interface RegisterReqBody {
   email: string
   category: string
   newsLetter: boolean
-  emailAuth: boolean
 }
 
 const useRegister = () => {

--- a/src/components/UserInfoForm/hooks/useRegister.ts
+++ b/src/components/UserInfoForm/hooks/useRegister.ts
@@ -1,0 +1,18 @@
+interface RegisterReqBody {
+  nickName: string
+  introduce: string
+  email: string
+  category: string
+  newsLetter: boolean
+  emailAuth: boolean
+}
+
+const useRegister = () => {
+  const registerLinkHub = (data: RegisterReqBody) => {
+    console.log('회원가입 로직', data)
+  }
+
+  return { registerLinkHub }
+}
+
+export { useRegister }

--- a/src/components/common/Avatar/Avatar.tsx
+++ b/src/components/common/Avatar/Avatar.tsx
@@ -1,4 +1,5 @@
 import { CSSProperties } from 'react'
+import { cls } from '@/utils'
 import Image from 'next/image'
 
 export interface AvatarProps {
@@ -7,9 +8,10 @@ export interface AvatarProps {
   height: number
   alt: string
   style?: CSSProperties
+  className?: string
 }
 
-const Avatar = ({ src, width, height, alt }: AvatarProps) => {
+const Avatar = ({ src, width, height, alt, className }: AvatarProps) => {
   return (
     <div className="inline-block">
       <Image
@@ -17,7 +19,10 @@ const Avatar = ({ src, width, height, alt }: AvatarProps) => {
         width={width}
         height={height}
         alt={alt}
-        className="border-slate3 rounded-full border object-cover"
+        className={cls(
+          className,
+          'rounded-full border border-slate3 object-cover',
+        )}
       />
     </div>
   )

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -52,6 +52,7 @@ const Input = forwardRef(
           />
           {inputButton && (
             <button
+              type="button"
               className={cls(
                 'absolute right-0 top-0 flex rounded-r-md border px-4 py-2.5 text-sm font-semibold text-white',
                 buttonColor === 'green'

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -98,7 +98,10 @@ export const mock_memberData = [
 export const mock_userData = {
   id: 3,
   name: '프롱이',
+  introduce: '반갑습니다!!',
   profile: '/duck.jpg',
+  category: '엔터테인먼트•예술',
+  newsLetter: false,
   mySpaces: [
     {
       name: 'My Space 1',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,3 +9,20 @@ export interface Space {
   scrap: number
   comment: boolean
 }
+
+export interface User {
+  id: number
+  name: string
+  introduce: string
+  profile: string
+  category: string
+  newsLetter: boolean
+  mySpaces: {
+    name: string
+    id: string
+  }[]
+  favoriteSpaces: {
+    name: string
+    id: string
+  }[]
+}


### PR DESCRIPTION
## 📑 이슈 번호
#55 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
### 회원가입 폼과 페이지를 구현했습니다.
![registerTest](https://github.com/Team-TenTen/LinkHub-FE/assets/66124037/04b3b37d-02e3-4574-9ea6-0af9a90f837a)

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### Todo: 이메일 인증 로직, 
### 공통 컴포넌트 수정사항
- Input 컴포넌트의 button에 type이 없어 type='button'을 추가하였습니다.

### PR 후 새로 추가된 수정사항
- 사용자 프로필 수정 form에서 사용할 시 기존 데이터를 불러와 defaultValue로 넣어주었습니다.
- Avatar 컴포넌트에 className을 props로 받을 수 있도록 수정했습니다.
- User 데이터와 인터페이스를 사용자 프로필 수정 form에서 사용할 수 있도록 수정하였습니다.