### PR TITLE
메인 스페이스 조회 api 연결

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  images: {
+    domains: ['team-10-bucket.s3.ap-northeast-2.amazonaws.com'],
+  },
+}
 
 module.exports = nextConfig

--- a/src/app/(routes)/space/[spaceId]/setting/page.tsx
+++ b/src/app/(routes)/space/[spaceId]/setting/page.tsx
@@ -7,7 +7,7 @@ const SpaceSettingPage = () => {
     spaceImage: '/TestImage.svg',
     spaceName: '강남역 맛집 리스트 모음 스페이스',
     description: '내 기준 강남역에서 맛있는 맛집 링크 모음집',
-    category: '생활•노하우•쇼핑',
+    category: 'LIFE_KNOWHOW_SHOPPING',
     favorite: 60,
     scrap: 40,
     spacePublic: true,

--- a/src/app/api/spaces/route.ts
+++ b/src/app/api/spaces/route.ts
@@ -1,0 +1,17 @@
+import { apiServer } from '@/services/apiServices'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const path = '/spaces'
+
+  try {
+    const data = await apiServer.get(`${path}?${searchParams}`)
+    return NextResponse.json(data)
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.errorMessage },
+      { status: error.response.status },
+    )
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -45,17 +45,17 @@ export default function Home() {
           />
         </div>
         <div className="flex flex-col gap-y-2 px-4 pt-2">
-          {spaces.map((space) => (
+          {spaces?.map((space) => (
             <Space
               userName={space.userName}
               spaceId={space.spaceId}
               type="Card"
               spaceName={space.spaceName}
-              spaceImage={space.spaceImage}
+              spaceImage={space.spaceImagePath}
               description={space.description}
               category={space.category}
-              scrap={space.scrap}
-              favorite={space.favorite}
+              scrap={space.scrapCount}
+              favorite={space.favoriteCount}
               key={space.spaceId}
             />
           ))}

--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -58,7 +58,7 @@ const SpaceForm = ({
     defaultValues: {
       name: spaceName || '',
       description: description || '',
-      category: category || '엔터테인먼트•예술',
+      category: category?.toLowerCase() || 'enter_art',
       public: spacePublic || false,
       comment: comment || false,
       summary: summary || false,
@@ -145,7 +145,7 @@ const SpaceForm = ({
             <CategoryList
               type="default"
               horizontal={false}
-              defaultIndex={CATEGORIES['default'].indexOf(
+              defaultIndex={Object.values(CATEGORIES['default']).indexOf(
                 getValues('category'),
               )}
               onChange={(e) =>

--- a/src/components/UserInfoForm/UserInfoForm.tsx
+++ b/src/components/UserInfoForm/UserInfoForm.tsx
@@ -49,7 +49,7 @@ const UserInfoForm = ({ userData, formType }: UserInfoFormProps) => {
     defaultValues: {
       nickName: userData?.name || '',
       introduce: userData?.description || '',
-      category: userData?.category || '엔터테인먼트•예술',
+      category: userData?.category.toLowerCase() || 'enter_art',
       newsLetter: userData?.newsLetter || false,
     },
   })
@@ -167,7 +167,9 @@ const UserInfoForm = ({ userData, formType }: UserInfoFormProps) => {
         <CategoryList
           type="default"
           horizontal={false}
-          defaultIndex={CATEGORIES['default'].indexOf(getValues('category'))}
+          defaultIndex={Object.values(CATEGORIES['default']).indexOf(
+            getValues('category'),
+          )}
           onChange={(e) => setValue('category', e?.currentTarget.value || '')}
         />
       </div>

--- a/src/components/common/CategoryList/CategoryList.tsx
+++ b/src/components/common/CategoryList/CategoryList.tsx
@@ -42,6 +42,7 @@ const CategoryList = ({
           key={category}>
           <CategoryListItem
             label={category}
+            value={categoryValues[i]}
             active={index === i}
             onClick={(e) => handleClick(e, i)}
           />

--- a/src/components/common/CategoryList/CategoryList.tsx
+++ b/src/components/common/CategoryList/CategoryList.tsx
@@ -18,6 +18,8 @@ const CategoryList = ({
   defaultIndex,
   onChange,
 }: CategoryListProps) => {
+  const categoryKeys = Object.keys(CATEGORIES[type])
+  const categoryValues = Object.values(CATEGORIES[type])
   const { index, handleClick } = useCategoryList({
     defaultIndex,
     onChange,
@@ -31,7 +33,7 @@ const CategoryList = ({
           ? 'horizontal-scroll snap-x scroll-px-4 overflow-x-auto scroll-smooth py-4'
           : 'flex-wrap',
       )}>
-      {CATEGORIES[type].map((category, i) => (
+      {categoryKeys.map((category, i) => (
         <li
           className={cls(
             'shrink-0',

--- a/src/components/common/CategoryList/CategoryListItem.tsx
+++ b/src/components/common/CategoryList/CategoryListItem.tsx
@@ -2,6 +2,7 @@ import { cls } from '@/utils'
 
 export interface CategoryListItemProps {
   label: string
+  value?: string
   active: boolean
   disabled?: boolean
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
@@ -9,6 +10,7 @@ export interface CategoryListItemProps {
 
 const CategoryListItem = ({
   label,
+  value,
   active = false,
   disabled,
   onClick,
@@ -16,7 +18,7 @@ const CategoryListItem = ({
   return (
     <button
       type="button"
-      value={label}
+      value={value}
       className={cls(
         'rounded-3xl border px-4 py-2 text-sm font-medium',
         active

--- a/src/components/common/CategoryList/constants/index.ts
+++ b/src/components/common/CategoryList/constants/index.ts
@@ -1,13 +1,13 @@
-const DEFAULT = [
-  '엔터테인먼트•예술',
-  '생활•노하우•쇼핑',
-  '취미•여가•여행',
-  '지식•이슈•커리어',
-  '기타',
-]
+const DEFAULT = {
+  '엔터테인먼트•예술': 'enter_art',
+  '생활•노하우•쇼핑': 'life_knowhow_shopping',
+  '취미•여가•여행': 'hobby_leisure_travel',
+  '지식•이슈•커리어': 'knowledge_issue_career',
+  기타: 'etc',
+}
 
 export const CATEGORIES = {
   default: DEFAULT,
-  all: ['전체', ...DEFAULT],
-  all_follow: ['전체', '팔로우', ...DEFAULT],
+  all: { 전체: 'all', ...DEFAULT },
+  all_follow: { 전체: 'all', 팔로우: 'follow', ...DEFAULT },
 }

--- a/src/components/common/Dropdown/constants/index.ts
+++ b/src/components/common/Dropdown/constants/index.ts
@@ -1,6 +1,6 @@
 export const DROPDOWN_OPTIONS = {
-  space: { 최신순: 'recent', 즐겨찾기순: 'scrap' },
-  link: { 최신순: 'recent', 좋아요순: 'favorite' },
+  space: { 최신순: 'recent', 즐겨찾기순: 'favorite' },
+  link: { 최신순: 'recent', 좋아요순: 'like' },
   search: { 스페이스: 'space', 유저: 'user' },
   user_edit: { '편집 허용': 'edit', '읽기 허용': 'view', 제거: 'remove' },
   user_invite: { '편집 허용': 'eidt', '읽기 허용': 'view' },

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -20,3 +20,6 @@ export const COLOR_LIST = [
   'pink',
   'gray',
 ]
+
+export const PAGE_SIZE = 10
+export const PAGE_NUMBER = 0

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -107,7 +107,7 @@ export const mock_userData: User = {
   id: '3',
   name: '프롱이',
   profile: '/duck.jpg',
-  category: '엔터테인먼트•예술',
+  category: 'ENTER_ART',
   newsLetter: false,
   email: 'abc@gmail.com',
   description: '쇼핑 정보를 모으고 있어요!',

--- a/src/hooks/useHome.ts
+++ b/src/hooks/useHome.ts
@@ -1,7 +1,9 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { CATEGORIES } from '@/components/common/CategoryList/constants'
 import { DROPDOWN_OPTIONS } from '@/components/common/Dropdown/constants'
-import { mock_LinkData, mock_spacesData } from '@/data'
+import { mock_LinkData } from '@/data'
+import { fetchGetSpaces } from '@/services/space/spaces'
+import { SpaceResBody } from '@/types'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
 const useHome = () => {
@@ -17,7 +19,29 @@ const useHome = () => {
     ? Object.values(CATEGORIES['all_follow']).indexOf(category)
     : 0
   const links = mock_LinkData.slice(0, 5)
-  const spaces = mock_spacesData
+  const [spaces, setSpaces] = useState<SpaceResBody[]>([])
+
+  useEffect(() => {
+    const category = searchParams.get('category')
+    const sort = searchParams.get('sort')
+
+    if (category === 'follow') {
+      // TODO: 팔로잉 중인 유저 스페이스 불러오기
+      setSpaces([])
+    } else {
+      fetchGetSpaces({
+        pageNumber: 0,
+        pageSize: 10,
+        sort: sort === 'favorite' ? 'favorite_count' : 'created_at',
+        filter:
+          category === null || category === 'all'
+            ? ''
+            : category?.toUpperCase(),
+      }).then((res) => {
+        setSpaces(res.responses)
+      })
+    }
+  }, [searchParams])
 
   const createQueryString = useCallback(
     (name: string, value: string) => {

--- a/src/hooks/useHome.ts
+++ b/src/hooks/useHome.ts
@@ -10,11 +10,11 @@ const useHome = () => {
   const searchParams = useSearchParams()
   const sort = searchParams.get('sort')
   const category = searchParams.get('category')
-  const categoryIndex = category
-    ? CATEGORIES['all_follow'].indexOf(category)
-    : 0
   const sortIndex = sort
     ? Object.values(DROPDOWN_OPTIONS['space']).indexOf(sort)
+    : 0
+  const categoryIndex = category
+    ? Object.values(CATEGORIES['all_follow']).indexOf(category)
     : 0
   const links = mock_LinkData.slice(0, 5)
   const spaces = mock_spacesData

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -14,7 +14,9 @@ const useSearch = () => {
   const sortIndex = sort
     ? Object.values(DROPDOWN_OPTIONS['space']).indexOf(sort)
     : 0
-  const categoryIndex = category ? CATEGORIES['all'].indexOf(category) : 0
+  const categoryIndex = category
+    ? Object.values(CATEGORIES['all']).indexOf(category)
+    : 0
   const keyword = searchParams.get('keyword')
   const result =
     target === 'space'

--- a/src/services/space/spaces.ts
+++ b/src/services/space/spaces.ts
@@ -1,0 +1,27 @@
+import { SearchSpaceReqBody } from '@/types'
+import { apiClient } from '../apiServices'
+
+const fetchGetSpaces = async ({
+  pageNumber,
+  pageSize,
+  sort,
+  filter,
+}: SearchSpaceReqBody) => {
+  const path = '/api/spaces'
+  const params = {
+    pageNumber: pageNumber.toString(),
+    pageSize: pageSize.toString(),
+    sort: sort,
+    filter: filter,
+  }
+  const queryString = new URLSearchParams(params).toString()
+
+  try {
+    const response = await apiClient.get(`${path}?${queryString}`)
+    return response
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
+}
+
+export { fetchGetSpaces }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -111,7 +111,7 @@ export interface SearchSpaceReqBody {
   pageNumber: number
   pageSize: number
   sort: string
-  keyWord: string
+  keyWord?: string
   filter: string
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -138,10 +138,21 @@ export interface SpaceReqBody {
 }
 
 // 링크 생성 req body
-
 export interface CreateLinkReqBody {
   url: string
   title: string
   tag: string
   color: string
+}
+
+export interface SpaceResBody {
+  spaceId: number
+  spaceName: string
+  description: string
+  userName: string
+  category: string
+  viewCount: number
+  scrapCount: number
+  favoriteCount: number
+  spaceImagePath: string
 }


### PR DESCRIPTION
## 📑 이슈 번호
- close #104 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
메인 스페이스 조회 api 연결했습니다.

https://github.com/Team-TenTen/LinkHub-FE/assets/49032882/5f058282-4336-4349-bea9-7ddb931b781e

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### SpaceResBody 
스페이스 조회 api response 타입을 추가했습니다.
```ts
export interface SpaceResBody {
  spaceId: number
  spaceName: string
  description: string
  userName: string // 아직 userName 없음
  category: string
  viewCount: number
  scrapCount: number
  favoriteCount: number
  spaceImagePath: string
}
```

### CategoryList constants
- 카테고리 옵션을 `type: [옵션_한글]`에서 `type: {옵션_한글: 옵션_영문}`으로 수정했습니다.
- CategoryList의 type은 기존과 동일한 방식으로 넘겨주시면 됩니다.
```ts
const DEFAULT = {
  '엔터테인먼트•예술': 'enter_art',
  '생활•노하우•쇼핑': 'life_knowhow_shopping',
  '취미•여가•여행': 'hobby_leisure_travel',
  '지식•이슈•커리어': 'knowledge_issue_career',
  기타: 'etc',
}

export const CATEGORIES = {
  default: DEFAULT,
  all: { 전체: 'all', ...DEFAULT },
  all_follow: { 전체: 'all', 팔로우: 'follow', ...DEFAULT },
}
```

### CategoryListItemProps
- Dropdown과 동일하게 value로 영문을 받아옵니다.
- 카테고리 항목을 API로 넘겨줄 때 대문자로 치환해야 합니다! (프론트단에서 쓸 때는 소문자로 치환) ⚠️
```ts
interface CategoryListItemProps {
  label: string
  value?: string // 추가
  active: boolean
  disabled?: boolean
  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
}
```

### Dropdown constants
명세와 일치하지 않는 옵션명이 있어 수정했습니다.
```ts
export const DROPDOWN_OPTIONS = {
  space: { 최신순: 'recent', 즐겨찾기순: 'favorite' }, // scrap -> favorite
  link: { 최신순: 'recent', 좋아요순: 'like' }, // favorite -> like
}
```