### PR TITLE
스페이스 즐겨찾기 api 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
-        "lodash": "^4.17.21",
         "@tanstack/react-query": "^5.8.4",
         "@types/js-cookie": "^3.0.6",
         "js-cookie": "^3.0.5",
+        "lodash": "^4.17.21",
         "next": "13.5.6",
         "next-themes": "^0.2.1",
         "open-graph-scraper": "^6.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
+        "lodash": "^4.17.21",
         "next": "13.5.6",
         "next-themes": "^0.2.1",
         "open-graph-scraper": "^6.3.2",
@@ -19,6 +20,7 @@
       },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.2.1",
+        "@types/lodash": "^4.14.201",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -846,6 +848,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.201",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.201.tgz",
+      "integrity": "sha512-y9euML0cim1JrykNxADLfaG0FgD1g/yTHwUs/Jg9ZIU7WKj2/4IW9Lbb1WZbvck78W/lfGXFfe+u2EGfIJXdLQ==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -3637,8 +3645,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.18",
+    "lodash": "^4.17.21",
     "next": "13.5.6",
     "next-themes": "^0.2.1",
     "open-graph-scraper": "^6.3.2",
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.2.1",
+    "@types/lodash": "^4.14.201",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/app/(routes)/space/[spaceId]/comment/page.tsx
+++ b/src/app/(routes)/space/[spaceId]/comment/page.tsx
@@ -43,6 +43,7 @@ const SpaceCommentPage = () => {
     <>
       <Space
         userName={space.memberDetailInfos[0].nickname}
+        spaceId={space.spaceId}
         type="Header"
         spaceName={space.spaceName}
         spaceImage={space.spaceImagePath}

--- a/src/app/(routes)/space/[spaceId]/page.tsx
+++ b/src/app/(routes)/space/[spaceId]/page.tsx
@@ -32,12 +32,14 @@ const SpacePage = () => {
         <Space
           type="Header"
           userName={space.memberDetailInfos[0].nickname}
+          spaceId={space.spaceId}
           spaceName={space.spaceName}
           spaceImage={space.spaceImagePath}
           description={space.description}
           category={CATEGORIES_RENDER[space.category]}
           scrap={space.scrapCount}
           favorite={space.favoriteCount}
+          hasFavorite={space.hasFavorite}
         />
       )}
       {tabList.length > MIN_TAB_NUMBER && (

--- a/src/app/(routes)/user/[userId]/favorite/page.tsx
+++ b/src/app/(routes)/user/[userId]/favorite/page.tsx
@@ -40,6 +40,7 @@ const UserFavoritePage = () => {
             key={space.spaceId}
             type="Card"
             userName={space.userName}
+            spaceId={space.spaceId}
             spaceName={space.spaceName}
             spaceImage={space.spaceImage}
             description={space.description}

--- a/src/app/(routes)/user/[userId]/space/page.tsx
+++ b/src/app/(routes)/user/[userId]/space/page.tsx
@@ -43,6 +43,7 @@ const UserSpacePage = () => {
             key={space.spaceId}
             type="Card"
             userName={space.userName}
+            spaceId={space.spaceId}
             spaceName={space.spaceName}
             spaceImage={space.spaceImage}
             description={space.description}

--- a/src/app/api/favorites/[spaceId]/route.ts
+++ b/src/app/api/favorites/[spaceId]/route.ts
@@ -1,0 +1,20 @@
+import { apiServer } from '@/services/apiServices'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(req: NextRequest) {
+  const { spaceId } = await req.json()
+  const path = `/spaces/${spaceId}/favorites`
+  const headers = {
+    Authorization: `Bearer ${req.cookies.get('token')?.value}`,
+  }
+
+  try {
+    const data = await apiServer.post(path, {}, {}, headers)
+    return NextResponse.json({ data })
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.message },
+      { status: error.response.status },
+    )
+  }
+}

--- a/src/app/api/favorites/[spaceId]/route.ts
+++ b/src/app/api/favorites/[spaceId]/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: NextRequest) {
 
   try {
     const data = await apiServer.post(path, {}, {}, headers)
-    return NextResponse.json({ data })
+    return NextResponse.json(data)
   } catch (error: any) {
     return NextResponse.json(
       { error: error.response.data.message },
@@ -31,7 +31,7 @@ export async function DELETE(req: NextRequest) {
 
   try {
     const data = await apiServer.delete(path, {}, headers)
-    return NextResponse.json({ data })
+    return NextResponse.json(data)
   } catch (error: any) {
     return NextResponse.json(
       { error: error.response.data.message },

--- a/src/app/api/favorites/[spaceId]/route.ts
+++ b/src/app/api/favorites/[spaceId]/route.ts
@@ -18,3 +18,21 @@ export async function POST(req: NextRequest) {
     )
   }
 }
+
+export async function DELETE(req: NextRequest) {
+  const spaceId = req.nextUrl.pathname.replace('/api/favorites/', '')
+  const path = `/spaces/${spaceId}/favorites`
+  const headers = {
+    Authorization: `Bearer ${req.cookies.get('token')?.value}`,
+  }
+
+  try {
+    const data = await apiServer.delete(path, {}, headers)
+    return NextResponse.json({ data })
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.message },
+      { status: error.response.status },
+    )
+  }
+}

--- a/src/app/api/favorites/[spaceId]/route.ts
+++ b/src/app/api/favorites/[spaceId]/route.ts
@@ -1,11 +1,13 @@
+import { useServerCookie } from '@/hooks/useServerCookie'
 import { apiServer } from '@/services/apiServices'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function POST(req: NextRequest) {
+  const { token } = useServerCookie()
   const { spaceId } = await req.json()
   const path = `/spaces/${spaceId}/favorites`
   const headers = {
-    Authorization: `Bearer ${req.cookies.get('token')?.value}`,
+    Authorization: `Bearer ${token}`,
   }
 
   try {
@@ -20,10 +22,11 @@ export async function POST(req: NextRequest) {
 }
 
 export async function DELETE(req: NextRequest) {
+  const { token } = useServerCookie()
   const spaceId = req.nextUrl.pathname.replace('/api/favorites/', '')
   const path = `/spaces/${spaceId}/favorites`
   const headers = {
-    Authorization: `Bearer ${req.cookies.get('token')?.value}`,
+    Authorization: `Bearer ${token}`,
   }
 
   try {

--- a/src/app/api/link/route.ts
+++ b/src/app/api/link/route.ts
@@ -1,12 +1,14 @@
+import { useServerCookie } from '@/hooks/useServerCookie'
 import { apiServer } from '@/services/apiServices'
 import { NextRequest, NextResponse } from 'next/server'
 
-export async function POST(req: NextRequest, res: NextResponse) {
+export async function POST(req: NextRequest) {
+  const { token } = useServerCookie()
   const { spaceId, url, title, tag, color } = await req.json()
   const path = `/spaces/${spaceId}/links`
   const body = { url, title, tag, color }
   const headers = {
-    Authorization: `Bearer ${req.cookies.get('token')?.value}`,
+    Authorization: `Bearer ${token}`,
   }
 
   try {

--- a/src/app/api/space/[spaceId]/route.ts
+++ b/src/app/api/space/[spaceId]/route.ts
@@ -4,9 +4,12 @@ import { NextRequest, NextResponse } from 'next/server'
 export async function GET(req: NextRequest) {
   const spaceId = req.nextUrl.pathname.replace('/api/space/', '')
   const path = `/spaces/${spaceId}`
+  const headers = {
+    Authorization: `Bearer ${req.cookies.get('token')?.value}`,
+  }
 
   try {
-    const space = await apiServer.get(path)
+    const space = await apiServer.get(path, { cache: 'no-cache' }, headers)
     return NextResponse.json({ space })
   } catch (error: any) {
     return NextResponse.json(

--- a/src/app/api/space/[spaceId]/route.ts
+++ b/src/app/api/space/[spaceId]/route.ts
@@ -1,11 +1,13 @@
+import { useServerCookie } from '@/hooks/useServerCookie'
 import { apiServer } from '@/services/apiServices'
 import { NextRequest, NextResponse } from 'next/server'
 
 export async function GET(req: NextRequest) {
+  const { token } = useServerCookie()
   const spaceId = req.nextUrl.pathname.replace('/api/space/', '')
   const path = `/spaces/${spaceId}`
   const headers = {
-    Authorization: `Bearer ${req.cookies.get('token')?.value}`,
+    Authorization: `Bearer ${token}`,
   }
 
   try {

--- a/src/components/common/Modal/LoginModal.tsx
+++ b/src/components/common/Modal/LoginModal.tsx
@@ -1,0 +1,33 @@
+import { LOGIN } from '@/constants'
+import { useRouter } from 'next/navigation'
+import Modal from './Modal'
+
+export interface LoginModalProps {
+  Modal: typeof Modal
+  isOpen: boolean
+  modalClose: VoidFunction
+}
+
+const LoginModal = ({ Modal, isOpen, modalClose }: LoginModalProps) => {
+  const router = useRouter()
+
+  return (
+    <>
+      {isOpen && (
+        <Modal
+          title={'알림'}
+          isCancelButton
+          isConfirmButton
+          onClose={modalClose}
+          onConfirm={() => router.push('/login')}>
+          <div className="flex flex-col items-center text-base font-medium text-gray9">
+            <div>{LOGIN.LOGIN_SERVICE}</div>
+            <div>{LOGIN.LOGIN_ASK}</div>
+          </div>
+        </Modal>
+      )}
+    </>
+  )
+}
+
+export default LoginModal

--- a/src/components/common/Space/Space.tsx
+++ b/src/components/common/Space/Space.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { LOGIN } from '@/constants'
 import { useModal } from '@/hooks'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { StarIcon as StarIconOutline } from '@heroicons/react/24/outline'
@@ -8,7 +7,6 @@ import { InboxArrowDownIcon } from '@heroicons/react/24/solid'
 import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import Button from '../Button/Button'
 import Chip from '../Chip/Chip'
 import LoginModal from '../Modal/LoginModal'
@@ -43,12 +41,11 @@ const Space = ({
   onClickScrap,
 }: SpaceProps) => {
   const { isLoggedIn } = useCurrentUser()
-  const { isFavorites, favoritesCount, debounceHandleClickFavoriteButton } =
-    useFavorites({
-      spaceId,
-      hasFavorite,
-      favorite,
-    })
+  const { isFavorites, favoritesCount, handleFavoriteClick } = useFavorites({
+    spaceId,
+    hasFavorite,
+    favorite,
+  })
   const { Modal, isOpen, modalOpen, modalClose } = useModal()
 
   const handleClickScrapButton = () => {
@@ -126,7 +123,7 @@ const Space = ({
               <Button
                 className="button button-round button-white"
                 onClick={() => {
-                  isLoggedIn ? debounceHandleClickFavoriteButton() : modalOpen()
+                  isLoggedIn ? handleFavoriteClick(isFavorites) : modalOpen()
                 }}>
                 {isFavorites ? (
                   <StarIconSolid className="h-4 w-4 text-yellow-300" />

--- a/src/components/common/Space/Space.tsx
+++ b/src/components/common/Space/Space.tsx
@@ -7,12 +7,12 @@ import Image from 'next/image'
 import Link from 'next/link'
 import Button from '../Button/Button'
 import Chip from '../Chip/Chip'
-import useToggle from '../Toggle/hooks/useToggle'
 import { SPACE_CONSTANT } from './constants'
+import useFavorites from './hooks/useFavorites'
 
 interface SpaceProps {
   userName: string
-  spaceId?: number
+  spaceId: number
   type: 'Card' | 'Header'
   spaceName: string
   spaceImage?: string
@@ -20,6 +20,7 @@ interface SpaceProps {
   category: string
   scrap: number
   favorite: number
+  hasFavorite: boolean
   onClickScrap?: (_e?: React.MouseEvent<HTMLButtonElement>) => void
   onClickFavorite?: (_e?: React.MouseEvent<HTMLButtonElement>) => void
 }
@@ -34,18 +35,14 @@ const Space = ({
   category,
   scrap,
   favorite,
+  hasFavorite,
   onClickScrap,
-  onClickFavorite,
 }: SpaceProps) => {
-  const [clicked, toggle] = useToggle()
+  const { isFavorites, favoritesCount, handleClickFavoriteButton } =
+    useFavorites({ spaceId, hasFavorite, favorite })
 
   const handleClickScrapButton = () => {
     onClickScrap?.()
-  }
-
-  const handleClickFavoriteButton = () => {
-    toggle()
-    onClickFavorite?.()
   }
 
   return (
@@ -119,12 +116,12 @@ const Space = ({
               <Button
                 className="button button-round button-white"
                 onClick={handleClickFavoriteButton}>
-                {clicked ? (
+                {isFavorites ? (
                   <StarIconSolid className="h-4 w-4 text-yellow-300" />
                 ) : (
                   <StarIconOutline className="h-4 w-4" />
                 )}
-                {SPACE_CONSTANT.FAVORITE} {favorite}
+                {SPACE_CONSTANT.FAVORITE} {favoritesCount}
               </Button>
             </div>
             <div className="line-clamp-1 text-xs font-normal text-gray6">

--- a/src/components/common/Space/Space.tsx
+++ b/src/components/common/Space/Space.tsx
@@ -2,6 +2,7 @@
 
 import { LOGIN } from '@/constants'
 import { useModal } from '@/hooks'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { StarIcon as StarIconOutline } from '@heroicons/react/24/outline'
 import { InboxArrowDownIcon } from '@heroicons/react/24/solid'
 import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid'
@@ -41,7 +42,7 @@ const Space = ({
   hasFavorite,
   onClickScrap,
 }: SpaceProps) => {
-  const token = document.cookie.split('=')[1] // token 가져오는 훅으로 변경 예정
+  const { isLoggedIn } = useCurrentUser()
   const { isFavorites, favoritesCount, debounceHandleClickFavoriteButton } =
     useFavorites({
       spaceId,
@@ -125,7 +126,7 @@ const Space = ({
               <Button
                 className="button button-round button-white"
                 onClick={() => {
-                  token ? debounceHandleClickFavoriteButton() : modalOpen()
+                  isLoggedIn ? debounceHandleClickFavoriteButton() : modalOpen()
                 }}>
                 {isFavorites ? (
                   <StarIconSolid className="h-4 w-4 text-yellow-300" />

--- a/src/components/common/Space/Space.tsx
+++ b/src/components/common/Space/Space.tsx
@@ -1,10 +1,13 @@
 'use client'
 
+import { LOGIN } from '@/constants'
+import { useModal } from '@/hooks'
 import { StarIcon as StarIconOutline } from '@heroicons/react/24/outline'
 import { InboxArrowDownIcon } from '@heroicons/react/24/solid'
 import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid'
 import Image from 'next/image'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import Button from '../Button/Button'
 import Chip from '../Chip/Chip'
 import { SPACE_CONSTANT } from './constants'
@@ -20,7 +23,7 @@ interface SpaceProps {
   category: string
   scrap: number
   favorite: number
-  hasFavorite: boolean
+  hasFavorite?: boolean
   onClickScrap?: (_e?: React.MouseEvent<HTMLButtonElement>) => void
 }
 
@@ -37,12 +40,15 @@ const Space = ({
   hasFavorite,
   onClickScrap,
 }: SpaceProps) => {
+  const token = document.cookie.split('=')[1] // token 가져오는 훅으로 변경 예정
+  const router = useRouter()
   const { isFavorites, favoritesCount, debounceHandleClickFavoriteButton } =
     useFavorites({
       spaceId,
       hasFavorite,
       favorite,
     })
+  const { Modal, isOpen, modalOpen, modalClose } = useModal()
 
   const handleClickScrapButton = () => {
     onClickScrap?.()
@@ -118,7 +124,9 @@ const Space = ({
               </Button>
               <Button
                 className="button button-round button-white"
-                onClick={debounceHandleClickFavoriteButton}>
+                onClick={() => {
+                  token ? debounceHandleClickFavoriteButton() : modalOpen()
+                }}>
                 {isFavorites ? (
                   <StarIconSolid className="h-4 w-4 text-yellow-300" />
                 ) : (
@@ -132,6 +140,19 @@ const Space = ({
             </div>
           </div>
         </div>
+      )}
+      {isOpen && (
+        <Modal
+          title={'알림'}
+          isCancelButton
+          isConfirmButton
+          onClose={modalClose}
+          onConfirm={() => router.push('/login')}>
+          <div className="flex flex-col items-center text-base font-medium text-gray9">
+            <div>{LOGIN.LOGIN_SERVICE}</div>
+            <div>{LOGIN.LOGIN_ASK}</div>
+          </div>
+        </Modal>
       )}
     </>
   )

--- a/src/components/common/Space/Space.tsx
+++ b/src/components/common/Space/Space.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import Button from '../Button/Button'
 import Chip from '../Chip/Chip'
+import LoginModal from '../Modal/LoginModal'
 import { SPACE_CONSTANT } from './constants'
 import useFavorites from './hooks/useFavorites'
 
@@ -41,7 +42,6 @@ const Space = ({
   onClickScrap,
 }: SpaceProps) => {
   const token = document.cookie.split('=')[1] // token 가져오는 훅으로 변경 예정
-  const router = useRouter()
   const { isFavorites, favoritesCount, debounceHandleClickFavoriteButton } =
     useFavorites({
       spaceId,
@@ -141,19 +141,11 @@ const Space = ({
           </div>
         </div>
       )}
-      {isOpen && (
-        <Modal
-          title={'알림'}
-          isCancelButton
-          isConfirmButton
-          onClose={modalClose}
-          onConfirm={() => router.push('/login')}>
-          <div className="flex flex-col items-center text-base font-medium text-gray9">
-            <div>{LOGIN.LOGIN_SERVICE}</div>
-            <div>{LOGIN.LOGIN_ASK}</div>
-          </div>
-        </Modal>
-      )}
+      <LoginModal
+        Modal={Modal}
+        isOpen={isOpen}
+        modalClose={modalClose}
+      />
     </>
   )
 }

--- a/src/components/common/Space/Space.tsx
+++ b/src/components/common/Space/Space.tsx
@@ -22,7 +22,6 @@ interface SpaceProps {
   favorite: number
   hasFavorite: boolean
   onClickScrap?: (_e?: React.MouseEvent<HTMLButtonElement>) => void
-  onClickFavorite?: (_e?: React.MouseEvent<HTMLButtonElement>) => void
 }
 
 const Space = ({
@@ -38,8 +37,12 @@ const Space = ({
   hasFavorite,
   onClickScrap,
 }: SpaceProps) => {
-  const { isFavorites, favoritesCount, handleClickFavoriteButton } =
-    useFavorites({ spaceId, hasFavorite, favorite })
+  const { isFavorites, favoritesCount, debounceHandleClickFavoriteButton } =
+    useFavorites({
+      spaceId,
+      hasFavorite,
+      favorite,
+    })
 
   const handleClickScrapButton = () => {
     onClickScrap?.()
@@ -115,7 +118,7 @@ const Space = ({
               </Button>
               <Button
                 className="button button-round button-white"
-                onClick={handleClickFavoriteButton}>
+                onClick={debounceHandleClickFavoriteButton}>
                 {isFavorites ? (
                   <StarIconSolid className="h-4 w-4 text-yellow-300" />
                 ) : (

--- a/src/components/common/Space/hooks/useFavorites.ts
+++ b/src/components/common/Space/hooks/useFavorites.ts
@@ -8,7 +8,7 @@ import useToggle from '../../Toggle/hooks/useToggle'
 
 export interface UseFavoritesProps {
   spaceId: number
-  hasFavorite: boolean
+  hasFavorite?: boolean
   favorite: number
 }
 

--- a/src/components/common/Space/hooks/useFavorites.ts
+++ b/src/components/common/Space/hooks/useFavorites.ts
@@ -1,0 +1,48 @@
+import { useState } from 'react'
+import {
+  fetchFavoriteSpace,
+  fetchUnFavoriteSpace,
+} from '@/services/favorites/favorites'
+import useToggle from '../../Toggle/hooks/useToggle'
+
+export interface UseFavoritesProps {
+  spaceId: number
+  hasFavorite: boolean
+  favorite: number
+  onClickFavorite?: (_e?: React.MouseEvent<HTMLButtonElement>) => void
+}
+
+const useFavorites = ({
+  spaceId,
+  hasFavorite,
+  favorite,
+  onClickFavorite,
+}: UseFavoritesProps) => {
+  const [isFavorites, favoritesToggle] = useToggle(hasFavorite)
+  const [favoritesCount, setFavoritesCount] = useState<number>(favorite)
+  const [isLoading, setLoading] = useState(false)
+
+  const handleClickFavoriteButton = async () => {
+    if (isLoading) return
+
+    setLoading(true)
+    favoritesToggle()
+
+    if (isFavorites) {
+      await fetchUnFavoriteSpace({ spaceId })
+      setFavoritesCount((prev) => prev - 1)
+    } else {
+      await fetchFavoriteSpace({ spaceId })
+      setFavoritesCount((prev) => prev + 1)
+    }
+
+    await onClickFavorite?.()
+    setTimeout(() => {
+      setLoading(false)
+    }, 200)
+  }
+
+  return { isFavorites, favoritesCount, handleClickFavoriteButton }
+}
+
+export default useFavorites

--- a/src/components/common/Space/hooks/useFavorites.ts
+++ b/src/components/common/Space/hooks/useFavorites.ts
@@ -3,29 +3,24 @@ import {
   fetchFavoriteSpace,
   fetchUnFavoriteSpace,
 } from '@/services/favorites/favorites'
+import { debounce } from 'lodash'
 import useToggle from '../../Toggle/hooks/useToggle'
 
 export interface UseFavoritesProps {
   spaceId: number
   hasFavorite: boolean
   favorite: number
-  onClickFavorite?: (_e?: React.MouseEvent<HTMLButtonElement>) => void
 }
 
 const useFavorites = ({
   spaceId,
   hasFavorite,
   favorite,
-  onClickFavorite,
 }: UseFavoritesProps) => {
   const [isFavorites, favoritesToggle] = useToggle(hasFavorite)
   const [favoritesCount, setFavoritesCount] = useState<number>(favorite)
-  const [isLoading, setLoading] = useState(false)
 
   const handleClickFavoriteButton = async () => {
-    if (isLoading) return
-
-    setLoading(true)
     favoritesToggle()
 
     if (isFavorites) {
@@ -35,14 +30,13 @@ const useFavorites = ({
       await fetchFavoriteSpace({ spaceId })
       setFavoritesCount((prev) => prev + 1)
     }
-
-    await onClickFavorite?.()
-    setTimeout(() => {
-      setLoading(false)
-    }, 200)
   }
 
-  return { isFavorites, favoritesCount, handleClickFavoriteButton }
+  const debounceHandleClickFavoriteButton = debounce(() => {
+    handleClickFavoriteButton()
+  }, 300)
+
+  return { isFavorites, favoritesCount, debounceHandleClickFavoriteButton }
 }
 
 export default useFavorites

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -36,3 +36,7 @@ export const CATEGORIES_RENDER: CategoriesRenderType = {
 export const PAGE_SIZE = 10
 export const PAGE_NUMBER = 0
 
+export const LOGIN = {
+  LOGIN_SERVICE: '로그인이 필요한 서비스입니다.',
+  LOGIN_ASK: '로그인하시겠습니까?',
+}

--- a/src/lib/fetchAPI.ts
+++ b/src/lib/fetchAPI.ts
@@ -51,7 +51,8 @@ class FetchAPI {
       body: type === 'multipart' ? body : JSON.stringify(body),
       ...nextInit,
     })
-    return response
+    const data = response.json()
+    return data
   }
   public async put(
     endpoint: string,
@@ -65,7 +66,8 @@ class FetchAPI {
       body: JSON.stringify(body),
       ...nextInit,
     })
-    return response
+    const data = response.json()
+    return data
   }
   public async delete(
     endpoint: string,

--- a/src/lib/fetchAPI.ts
+++ b/src/lib/fetchAPI.ts
@@ -51,8 +51,7 @@ class FetchAPI {
       body: type === 'multipart' ? body : JSON.stringify(body),
       ...nextInit,
     })
-    const data = response.json()
-    return data
+    return response
   }
   public async put(
     endpoint: string,

--- a/src/lib/fetchServerAPI.ts
+++ b/src/lib/fetchServerAPI.ts
@@ -51,7 +51,8 @@ class FetchServerAPI {
       body: type === 'multipart' ? body : JSON.stringify(body),
       ...nextInit,
     })
-    return response
+    const data = response.json()
+    return data
   }
   public async put(
     endpoint: string,
@@ -65,7 +66,8 @@ class FetchServerAPI {
       body: JSON.stringify(body),
       ...nextInit,
     })
-    return response
+    const data = response.json()
+    return data
   }
   public async delete(
     endpoint: string,
@@ -77,7 +79,8 @@ class FetchServerAPI {
       headers: { ...this.headers, ...customHeaders },
       ...nextInit,
     })
-    return response
+    const data = response
+    return data
   }
 }
 export default FetchServerAPI

--- a/src/lib/fetchServerAPI.ts
+++ b/src/lib/fetchServerAPI.ts
@@ -51,8 +51,7 @@ class FetchServerAPI {
       body: type === 'multipart' ? body : JSON.stringify(body),
       ...nextInit,
     })
-    const data = response.json()
-    return data
+    return response
   }
   public async put(
     endpoint: string,

--- a/src/services/favorites/favorites.ts
+++ b/src/services/favorites/favorites.ts
@@ -1,0 +1,19 @@
+import { apiClient } from '../apiServices'
+
+export interface FetchFavoriteSpaceProps {
+  spaceId: number
+}
+
+const fetchFavoriteSpace = async ({ spaceId }: FetchFavoriteSpaceProps) => {
+  const path = `/api/favorites/${spaceId}`
+  const body = { spaceId }
+
+  try {
+    const response = await apiClient.post(path, body)
+    return response.json()
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
+}
+
+export { fetchFavoriteSpace }

--- a/src/services/favorites/favorites.ts
+++ b/src/services/favorites/favorites.ts
@@ -16,4 +16,15 @@ const fetchFavoriteSpace = async ({ spaceId }: FetchFavoriteSpaceProps) => {
   }
 }
 
-export { fetchFavoriteSpace }
+const fetchUnFavoriteSpace = async ({ spaceId }: FetchFavoriteSpaceProps) => {
+  const path = `/api/favorites/${spaceId}`
+
+  try {
+    const response = await apiClient.delete(path)
+    return response.json()
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
+}
+
+export { fetchFavoriteSpace, fetchUnFavoriteSpace }

--- a/src/services/favorites/favorites.ts
+++ b/src/services/favorites/favorites.ts
@@ -10,7 +10,7 @@ const fetchFavoriteSpace = async ({ spaceId }: FetchFavoriteSpaceProps) => {
 
   try {
     const response = await apiClient.post(path, body)
-    return response.json()
+    return response
   } catch (e) {
     if (e instanceof Error) throw new Error(e.message)
   }
@@ -21,7 +21,7 @@ const fetchUnFavoriteSpace = async ({ spaceId }: FetchFavoriteSpaceProps) => {
 
   try {
     const response = await apiClient.delete(path)
-    return response.json()
+    return response
   } catch (e) {
     if (e instanceof Error) throw new Error(e.message)
   }

--- a/src/services/link/link.ts
+++ b/src/services/link/link.ts
@@ -17,7 +17,7 @@ const fetchCreateLink = async ({
 
   try {
     const response = await apiClient.post(path, body)
-    return response.json()
+    return response
   } catch (e) {
     if (e instanceof Error) throw new Error(e.message)
   }

--- a/src/services/meta/meta.ts
+++ b/src/services/meta/meta.ts
@@ -10,7 +10,7 @@ const fetchGetMeta = async ({ url }: FetchGetMetaProps) => {
 
   try {
     const response = await apiClient.post(path, body)
-    return response.json()
+    return response
   } catch (e) {
     if (e instanceof Error) throw new Error(e.message)
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -94,8 +94,10 @@ export interface SpaceDetailResBody {
   scrapCount: number
   favoriteCount: number
   spaceImagePath: string
-  memberDetailInfos: UserDetailInfo[]
+  hasFavorite: boolean
   isOwner: boolean
+  isCanEdit: boolean
+  memberDetailInfos: UserDetailInfo[]
 }
 
 export interface UserDetailInfo {


### PR DESCRIPTION
## 📑 이슈 번호
#109 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 좋아요 추가 api를 구현 및 적용하였습니다.
- 좋아요 취소 api를 구현 및 적용하였습니다.

### 로그인 한 유저가 클릭할 때
![Nov-19-2023 19-13-47](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/db7220e6-8ca1-4fbe-97b6-2140da3b7630)

### 로그인 하지 않은 유저가 클릭할 때
![Nov-19-2023 19-16-25](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/2b32dbc6-bd08-4583-b216-b24e84f37e49)

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### 스페이스 상세 조회 api에 토큰을 전달하는 headers를 추가하였습니다.
token을 같이 전달해야만 즐겨찾기 여부값인 hasFavorite이 정상적으로 반환됩니다.
token 없이 요청하면 hasFavorite은 무조건 false로 옵니다.

<br>

### LoginModal 컴포넌트 구현
로그인 알림 모달은 다른 곳에서도 많이 사용될 것 같아서 컴포넌트로 만들었습니다.
기존 useModal의 리턴값인 Modal, isOpen, modalClose만 전달하면 됩니다.
```tsx
const { Modal, isOpen, modalOpen, modalClose } = useModal()

...

return (
    <LoginModal
        Modal={Modal}
        isOpen={isOpen}
        modalClose={modalClose}
    />
)

```
<br>

### 좋아요 버튼을 클릭할 때 디바운스를 300ms로 적용하였는데 궁금한 점이 있습니다!

제가 생각한 디바운스는 연속 클릭 할 때 별 아이콘, 숫자는 즉시 변경 -> 연속 클릭이 끝났을 때 마지막 api 한 번 호출인데,
현재 로직은 연속 클릭 할 때는 아무것도 변경되지 않음 -> 연속 클릭이 끝났을 때 아이콘, 숫자 변경 및 마지막 api 한 번 호출되고 있습니다.

제대로 적용했는지 여러분들의 생각을 코멘트에 적어주시면 감사하겠습니다!

<hr>

기범님께서 구현하신 회원가입 / 로그인 코드 pull 받아서 변경점 적용하였습니다.
ex) 쿠키 가져오는 로직, 로그인 여부 등