### PR TITLE
링크 삭제 api 연결

### DIFF
--- a/src/app/(routes)/space/[spaceId]/page.tsx
+++ b/src/app/(routes)/space/[spaceId]/page.tsx
@@ -76,15 +76,18 @@ const SpacePage = () => {
             />
           </div>
           <div className="flex gap-2">
-            <Button
-              className="button button-white p-1.5"
-              onClick={editToggle}>
-              {isEdit ? (
-                <EyeIcon className="h-5 w-5" />
-              ) : (
-                <PencilSquareIcon className="h-5 w-5" />
-              )}
-            </Button>
+            {space?.isOwner && (
+              <Button
+                className="button button-white p-1.5"
+                onClick={editToggle}>
+                {isEdit ? (
+                  <EyeIcon className="h-5 w-5" />
+                ) : (
+                  <PencilSquareIcon className="h-5 w-5" />
+                )}
+              </Button>
+            )}
+
             <div>
               <Button
                 className={cls(

--- a/src/app/api/link/delete/route.ts
+++ b/src/app/api/link/delete/route.ts
@@ -1,0 +1,24 @@
+import { useServerCookie } from '@/hooks/useServerCookie'
+import { apiServer } from '@/services/apiServices'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function DELETE(req: NextRequest) {
+  const { token } = useServerCookie()
+  const { searchParams } = new URL(req.url)
+  const spaceId = searchParams.get('spaceId')
+  const linkId = searchParams.get('linkId')
+  const path = `/spaces/${spaceId}/links/${linkId}`
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  }
+
+  try {
+    const data = await apiServer.delete(path, {}, headers)
+    return NextResponse.json(data)
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.message },
+      { status: error.response.status },
+    )
+  }
+}

--- a/src/app/api/space/[spaceId]/route.ts
+++ b/src/app/api/space/[spaceId]/route.ts
@@ -11,8 +11,8 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const space = await apiServer.get(path, { cache: 'no-cache' }, headers)
-    return NextResponse.json({ space })
+    const data = await apiServer.get(path, { cache: 'no-cache' }, headers)
+    return NextResponse.json(data)
   } catch (error: any) {
     return NextResponse.json(
       { error: error.response.data.message },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,6 +19,7 @@ export default function Home() {
         <h2 className="py-4 font-bold text-gray9">인기있는 링크</h2>
         {links.map((link) => (
           <LinkItem
+            linkId={link.id}
             title={link.title}
             url={link.url}
             tag={link.tag}

--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCurrentModal, useModal } from '@/hooks'
+import { fetchDeleteLink } from '@/services/link/link'
 import { User } from '@/types'
 import { cls } from '@/utils'
 import {
@@ -18,8 +19,11 @@ import Chip from '../Chip/Chip'
 import Input from '../Input/Input'
 import useToggle from '../Toggle/hooks/useToggle'
 import { DELETE_TEXT } from './\bconstants'
+import useDeleteLink from './hooks/useDeleteLink'
 
 export interface LinkItemProps {
+  linkId: number
+  spaceId?: number
   title: string
   url: string
   tag: string
@@ -32,6 +36,8 @@ export interface LinkItemProps {
 }
 
 const LinkItem = ({
+  linkId,
+  spaceId,
   title,
   url,
   tag,
@@ -45,6 +51,7 @@ const LinkItem = ({
   const [isLike, likeToggle] = useToggle()
   const { Modal, isOpen, modalOpen, modalClose } = useModal()
   const [currentModal, handleChangeCurrentModal] = useCurrentModal()
+  const { handleDeleteLink } = useDeleteLink()
 
   return (
     <>
@@ -190,7 +197,8 @@ const LinkItem = ({
           isCancelButton={currentModal === 'update' ? false : true}
           isConfirmButton={true}
           confirmText={currentModal === 'update' ? '수정' : '삭제'}
-          onClose={modalClose}>
+          onClose={modalClose}
+          onConfirm={() => spaceId && handleDeleteLink({ spaceId, linkId })}>
           {currentModal === 'update' && (
             <div className="flex flex-col gap-2">
               <Input

--- a/src/components/common/LinkItem/hooks/useDeleteLink.ts
+++ b/src/components/common/LinkItem/hooks/useDeleteLink.ts
@@ -1,0 +1,14 @@
+import { FetchDeleteLinbkProps, fetchDeleteLink } from '@/services/link/link'
+
+const useDeleteLink = () => {
+  const handleDeleteLink = async ({
+    spaceId,
+    linkId,
+  }: FetchDeleteLinbkProps) => {
+    await fetchDeleteLink({ spaceId, linkId })
+  }
+
+  return { handleDeleteLink }
+}
+
+export default useDeleteLink

--- a/src/components/common/LinkList/LinkList.tsx
+++ b/src/components/common/LinkList/LinkList.tsx
@@ -76,7 +76,8 @@ const LinkList = ({
         </button>
         {links.map((link) => (
           <LinkItem
-            key={link.id}
+            spaceId={spaceId}
+            linkId={link.id}
             title={link.title}
             url={link.url}
             tag={link.tag}
@@ -86,6 +87,7 @@ const LinkList = ({
             summary={summary}
             edit={edit}
             type={type}
+            key={link.id}
           />
         ))}
       </div>

--- a/src/components/common/Space/hooks/useGetSpace.ts
+++ b/src/components/common/Space/hooks/useGetSpace.ts
@@ -20,8 +20,8 @@ const useGetSpace = (): [
   const spaceId = Number(path.split('/')[2])
 
   const handleGetSpace = useCallback(async () => {
-    const { space } = await fetchGetSpace({ spaceId })
-    setSpace(space)
+    const data = await fetchGetSpace({ spaceId })
+    setSpace(data)
   }, [spaceId])
 
   useEffect(() => {

--- a/src/components/common/Tab/utils/index.ts
+++ b/src/components/common/Tab/utils/index.ts
@@ -21,8 +21,7 @@ export const getPathname = ({ path, n, defaultPath }: GetPathnameProps) => {
 export const getCurrentSpaceTabList = (
   space: SpaceDetailResBody,
 ): TabList[] => {
-  const myName = 'dudwns' // TODO: 실제 유저로 변경
-  const { memberDetailInfos, spaceId, isComment } = space
+  const { isOwner, spaceId, isComment } = space
   const tabList = [
     { text: '스페이스', content: 'space', dest: `/space/${spaceId}` },
   ]
@@ -34,7 +33,7 @@ export const getCurrentSpaceTabList = (
       dest: `/space/${spaceId}/comment`,
     })
   }
-  if (memberDetailInfos[0].nickname === myName) {
+  if (isOwner) {
     tabList.push({
       text: '설정',
       content: 'setting',

--- a/src/services/link/link.ts
+++ b/src/services/link/link.ts
@@ -23,4 +23,24 @@ const fetchCreateLink = async ({
   }
 }
 
-export { fetchCreateLink }
+export interface FetchDeleteLinbkProps {
+  spaceId: number
+  linkId: number
+}
+const fetchDeleteLink = async ({ spaceId, linkId }: FetchDeleteLinbkProps) => {
+  const path = '/api/link/delete'
+  const params = {
+    spaceId: spaceId.toString(),
+    linkId: linkId.toString(),
+  }
+  const queryString = new URLSearchParams(params).toString()
+
+  try {
+    const response = await apiClient.delete(`${path}?${queryString}`)
+    return response
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
+}
+
+export { fetchCreateLink, fetchDeleteLink }


### PR DESCRIPTION
## 📑 이슈 번호
#118 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 링크 삭제 api를 구현 및 연결하였습니다.
- 링크 조회 API가 없기 때문에 아래 보이는 링크 리스트는 mock 데이터입니다. 따라서 삭제해도 변하지 않고 API만 연결해 둔 상태입니다.
- 링크 조회 API가 나오면 실제 링크의 id로 연결 할 예정입니다. 

![Nov-21-2023 04-56-27](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/4d239388-4713-47ca-bea1-126567fad138)


## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
- useTab 훅에서 space의 isOwner의 값이 true일 때만 설정 탭이 보이도록 변경하였습니다. 
- isOwner의 값이 true일 때만 edit 버튼이 보이도록 수정하였습니다.
<img width="500" alt="스크린샷 2023-11-21 오전 4 49 19" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/7f68b5a7-a755-4726-9af9-cb52636b8154">
