### PR TITLE
팔로잉, 팔로워 목록 조회 api 연결

### DIFF
--- a/src/app/(routes)/search/page.tsx
+++ b/src/app/(routes)/search/page.tsx
@@ -62,9 +62,9 @@ const SearchPage = () => {
         {target === 'user' &&
           users.map((user) => (
             <User
-              id={user.id}
-              name={user.name}
-              profile={user.profile}
+              memberId={user.id}
+              nickname={user.name}
+              profileImagePath={user.profile}
               key={user.id}
             />
           ))}

--- a/src/app/(routes)/user/[userId]/page.tsx
+++ b/src/app/(routes)/user/[userId]/page.tsx
@@ -19,9 +19,16 @@ const UserPage = () => {
   const router = useRouter()
   const { Modal, isOpen, modalClose, currentModal, handleOpenCurrentModal } =
     useModal()
-  const { isFollowing, followerCount, handleClickFollow } = useFollowUser({
+  const {
+    isFollowing,
+    followingCount,
+    setFollowingCount,
+    followerCount,
+    handleClickFollow,
+  } = useFollowUser({
     memberId: user?.memberId || 0,
     isInitFollowing: !!user?.isFollowing,
+    followingInitCount: user?.followingCount || 0,
     followerInitCount: user?.followerCount || 0,
     handleOpenCurrentModal,
   })
@@ -51,7 +58,7 @@ const UserPage = () => {
                 onClick={() => {
                   handleOpenCurrentModal('following')
                 }}>
-                {PROFILE_MSG.FOLLOWING} {user?.followingCount}
+                {PROFILE_MSG.FOLLOWING} {followingCount}
               </div>
               {PROFILE_MSG.LIST_DIVIDER}
               <div
@@ -70,9 +77,9 @@ const UserPage = () => {
             if (user?.memberId === myId) {
               router.push('/user/setting')
             } else if (isFollowing) {
-              handleClickFollow(!!isFollowing)
+              handleClickFollow(isFollowing)
             } else {
-              handleClickFollow(!!isFollowing)
+              handleClickFollow(isFollowing)
             }
           }}
           className={cls(
@@ -127,8 +134,9 @@ const UserPage = () => {
                 memberId={user?.memberId}
                 fetchFn={fetchGetFollowing}
                 myId={myId}
-                handleClickFollow={handleClickFollow}
                 type="following"
+                followingCount={followingCount}
+                setFollowingCount={setFollowingCount}
               />
             )}
             {currentModal === 'follower' && (
@@ -136,8 +144,9 @@ const UserPage = () => {
                 memberId={user?.memberId}
                 fetchFn={fetchGetFollowers}
                 myId={myId}
-                handleClickFollow={handleClickFollow}
                 type="follower"
+                followingCount={followingCount}
+                setFollowingCount={setFollowingCount}
               />
             )}
           </div>

--- a/src/app/(routes)/user/[userId]/page.tsx
+++ b/src/app/(routes)/user/[userId]/page.tsx
@@ -17,7 +17,7 @@ const UserPage = () => {
   const { Modal, isOpen, modalClose, currentModal, handleOpenCurrentModal } =
     useModal()
   const userData = mock_userData2 // TODO: 팔로워/팔로우 목록 API 나오면 제거
-  const { isFollowing, followerCount, handleFollowClick } = useFollowUser({
+  const { isFollowing, followerCount, handleClickFollow } = useFollowUser({
     memberId: user?.memberId || 0,
     isInitFollowing: !!user?.isFollowing,
     followerInitCount: user?.followerCount || 0,
@@ -68,9 +68,9 @@ const UserPage = () => {
             if (user?.memberId === myId) {
               router.push('/user/setting')
             } else if (isFollowing) {
-              handleFollowClick(!!isFollowing)
+              handleClickFollow(!!isFollowing)
             } else {
-              handleFollowClick(!!isFollowing)
+              handleClickFollow(!!isFollowing)
             }
           }}
           className={cls(

--- a/src/app/(routes)/user/[userId]/page.tsx
+++ b/src/app/(routes)/user/[userId]/page.tsx
@@ -2,12 +2,15 @@
 
 import { Avatar, CategoryListItem } from '@/components'
 import Button from '@/components/common/Button/Button'
+import FollowList from '@/components/common/FollowList/FollowList'
 import LoginModal from '@/components/common/Modal/LoginModal'
-import User from '@/components/common/User/User'
 import { CATEGORIES_RENDER, PROFILE_MSG } from '@/constants'
-import { mock_userData2 } from '@/data'
 import { useFollowUser, useModal } from '@/hooks'
 import useGetProfile from '@/hooks/useGetProfile'
+import {
+  fetchGetFollowers,
+  fetchGetFollowing,
+} from '@/services/user/follow/route'
 import { cls, getProfileButtonColor, getProfileButtonText } from '@/utils'
 import { useRouter } from 'next/navigation'
 
@@ -16,7 +19,6 @@ const UserPage = () => {
   const router = useRouter()
   const { Modal, isOpen, modalClose, currentModal, handleOpenCurrentModal } =
     useModal()
-  const userData = mock_userData2 // TODO: 팔로워/팔로우 목록 API 나오면 제거
   const { isFollowing, followerCount, handleClickFollow } = useFollowUser({
     memberId: user?.memberId || 0,
     isInitFollowing: !!user?.isFollowing,
@@ -120,36 +122,24 @@ const UserPage = () => {
           onClose={modalClose}
           type={'follow'}>
           <div className="flex flex-col gap-2">
-            {currentModal === 'following' &&
-              userData.following.map((user) => (
-                <User
-                  id={user.userId}
-                  name={user.userName}
-                  profile={user.profile}
-                  oneLiner={user.description}
-                  isFollow={user.isFollow}
-                  isAuth={123 === user.userId}
-                  onClick={(id, isFollow) =>
-                    console.log(isFollow ? `unfollow ${id}` : `follow ${id}`)
-                  }
-                  key={user.userId}
-                />
-              ))}
-            {currentModal === 'follower' &&
-              userData.follower.map((user) => (
-                <User
-                  id={user.userId}
-                  name={user.userName}
-                  profile={user.profile}
-                  oneLiner={user.description}
-                  isFollow={user.isFollow}
-                  isAuth={123 === user.userId}
-                  onClick={(id, isFollow) =>
-                    console.log(isFollow ? `unfollow ${id}` : `follow ${id}`)
-                  }
-                  key={user.userId}
-                />
-              ))}
+            {currentModal === 'following' && (
+              <FollowList
+                memberId={user?.memberId}
+                fetchFn={fetchGetFollowing}
+                myId={myId}
+                handleClickFollow={handleClickFollow}
+                type="following"
+              />
+            )}
+            {currentModal === 'follower' && (
+              <FollowList
+                memberId={user?.memberId}
+                fetchFn={fetchGetFollowers}
+                myId={myId}
+                handleClickFollow={handleClickFollow}
+                type="follower"
+              />
+            )}
           </div>
         </Modal>
       )}

--- a/src/app/api/favorites/[spaceId]/route.ts
+++ b/src/app/api/favorites/[spaceId]/route.ts
@@ -11,7 +11,8 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const data = await apiServer.post(path, {}, {}, headers)
+    const response = await apiServer.post(path, {}, {}, headers)
+    const data = await response.json()
     return NextResponse.json(data)
   } catch (error: any) {
     return NextResponse.json(

--- a/src/app/api/link/route.ts
+++ b/src/app/api/link/route.ts
@@ -12,8 +12,9 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const data = await apiServer.post(path, body, {}, headers)
-    return NextResponse.json({ data })
+    const response = await apiServer.post(path, body, {}, headers)
+    const data = await response.json()
+    return NextResponse.json(data)
   } catch (error: any) {
     return NextResponse.json(
       { error: error.response.data.message },

--- a/src/app/api/user/[memberId]/followers/route.ts
+++ b/src/app/api/user/[memberId]/followers/route.ts
@@ -1,0 +1,26 @@
+import { useServerCookie } from '@/hooks/useServerCookie'
+import { apiServer } from '@/services/apiServices'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { memberId: number } },
+) {
+  const { token } = useServerCookie()
+  const { searchParams } = new URL(req.url)
+  const memberId = params.memberId
+  const path = `/members/${memberId}/followers`
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  }
+
+  try {
+    const data = await apiServer.get(`${path}?${searchParams}`, {}, headers)
+    return NextResponse.json(data)
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.errorMessage },
+      { status: error.response.status },
+    )
+  }
+}

--- a/src/app/api/user/[memberId]/followers/route.ts
+++ b/src/app/api/user/[memberId]/followers/route.ts
@@ -15,7 +15,11 @@ export async function GET(
   }
 
   try {
-    const data = await apiServer.get(`${path}?${searchParams}`, {}, headers)
+    const data = await apiServer.get(
+      `${path}?${searchParams}`,
+      { cache: 'no-cache' },
+      headers,
+    )
     return NextResponse.json(data)
   } catch (error: any) {
     return NextResponse.json(

--- a/src/app/api/user/[memberId]/following/route.ts
+++ b/src/app/api/user/[memberId]/following/route.ts
@@ -1,0 +1,26 @@
+import { useServerCookie } from '@/hooks/useServerCookie'
+import { apiServer } from '@/services/apiServices'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { memberId: number } },
+) {
+  const { token } = useServerCookie()
+  const { searchParams } = new URL(req.url)
+  const memberId = params.memberId
+  const path = `/members/${memberId}/following`
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  }
+
+  try {
+    const data = await apiServer.get(`${path}?${searchParams}`, {}, headers)
+    return NextResponse.json(data)
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.errorMessage },
+      { status: error.response.status },
+    )
+  }
+}

--- a/src/app/api/user/[memberId]/following/route.ts
+++ b/src/app/api/user/[memberId]/following/route.ts
@@ -15,7 +15,11 @@ export async function GET(
   }
 
   try {
-    const data = await apiServer.get(`${path}?${searchParams}`, {}, headers)
+    const data = await apiServer.get(
+      `${path}?${searchParams}`,
+      { cache: 'no-cache' },
+      headers,
+    )
     return NextResponse.json(data)
   } catch (error: any) {
     return NextResponse.json(

--- a/src/app/api/user/follow/route.ts
+++ b/src/app/api/user/follow/route.ts
@@ -12,7 +12,8 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const data = await apiServer.post(path, {}, {}, headers)
+    const response = await apiServer.post(path, {}, {}, headers)
+    const data = await response.json()
     return NextResponse.json(data)
   } catch (error: any) {
     return NextResponse.json(
@@ -33,6 +34,7 @@ export async function DELETE(req: NextRequest) {
 
   try {
     const data = await apiServer.delete(path, {}, headers)
+
     return NextResponse.json(data)
   } catch (error: any) {
     return NextResponse.json(

--- a/src/app/api/user/follow/route.ts
+++ b/src/app/api/user/follow/route.ts
@@ -34,7 +34,6 @@ export async function DELETE(req: NextRequest) {
 
   try {
     const data = await apiServer.delete(path, {}, headers)
-
     return NextResponse.json(data)
   } catch (error: any) {
     return NextResponse.json(

--- a/src/components/common/FollowList/FollowList.tsx
+++ b/src/components/common/FollowList/FollowList.tsx
@@ -51,6 +51,7 @@ const FollowList = ({
                 isAuth={myId === user.memberId}
                 followingCount={followingCount}
                 myId={myId}
+                profileId={memberId}
                 setFollowingCount={setFollowingCount}
               />
             </li>

--- a/src/components/common/FollowList/FollowList.tsx
+++ b/src/components/common/FollowList/FollowList.tsx
@@ -1,0 +1,61 @@
+import { Fragment } from 'react'
+import useFollowQuery from '@/components/common/FollowList/hooks/useFollowQuery'
+import useInfiniteScroll from '@/hooks/useInfiniteScroll'
+import { FetchGetFollowProps } from '@/services/user/follow/route'
+import User from '../User/User'
+
+export interface FollowListProps {
+  memberId?: number
+  fetchFn: ({ pageNumber, pageSize }: FetchGetFollowProps) => Promise<any>
+  myId?: number
+  handleClickFollow?: (isFollowing: boolean) => void
+  type?: string
+}
+
+export interface FollowUserProps {
+  isFollowing: boolean
+  memberId?: number
+  nickname: string
+  profileImagePath: string
+  aboutMe: string
+}
+
+const FollowList = ({
+  memberId,
+  fetchFn,
+  myId,
+  handleClickFollow,
+  type,
+}: FollowListProps) => {
+  const { followList, fetchNextPage, hasNextPage } = useFollowQuery({
+    memberId,
+    fetchFn,
+    type,
+  })
+  const { target } = useInfiniteScroll({ hasNextPage, fetchNextPage })
+
+  return (
+    <ul className="flex flex-col gap-y-2">
+      {followList?.pages.map((group, i) => (
+        <Fragment key={i}>
+          {group.responses?.map((user: FollowUserProps) => (
+            <li key={user.memberId}>
+              <User
+                memberId={user.memberId}
+                nickname={user.nickname}
+                profileImagePath={user.profileImagePath}
+                aboutMe={user.aboutMe}
+                isFollowing={user.isFollowing}
+                isAuth={myId === user.memberId}
+                onClick={handleClickFollow}
+              />
+            </li>
+          ))}
+        </Fragment>
+      ))}
+      <div ref={target}></div>
+    </ul>
+  )
+}
+
+export default FollowList

--- a/src/components/common/FollowList/FollowList.tsx
+++ b/src/components/common/FollowList/FollowList.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react'
+import { Dispatch, Fragment, SetStateAction } from 'react'
 import useFollowQuery from '@/components/common/FollowList/hooks/useFollowQuery'
 import useInfiniteScroll from '@/hooks/useInfiniteScroll'
 import { FetchGetFollowProps } from '@/services/user/follow/route'
@@ -8,8 +8,9 @@ export interface FollowListProps {
   memberId?: number
   fetchFn: ({ pageNumber, pageSize }: FetchGetFollowProps) => Promise<any>
   myId?: number
-  handleClickFollow?: (isFollowing: boolean) => void
   type?: string
+  followingCount?: number
+  setFollowingCount?: Dispatch<SetStateAction<number | undefined>>
 }
 
 export interface FollowUserProps {
@@ -24,8 +25,9 @@ const FollowList = ({
   memberId,
   fetchFn,
   myId,
-  handleClickFollow,
   type,
+  followingCount,
+  setFollowingCount,
 }: FollowListProps) => {
   const { followList, fetchNextPage, hasNextPage } = useFollowQuery({
     memberId,
@@ -47,7 +49,9 @@ const FollowList = ({
                 aboutMe={user.aboutMe}
                 isFollowing={user.isFollowing}
                 isAuth={myId === user.memberId}
-                onClick={handleClickFollow}
+                followingCount={followingCount}
+                myId={myId}
+                setFollowingCount={setFollowingCount}
               />
             </li>
           ))}

--- a/src/components/common/FollowList/hooks/useFollowQuery.ts
+++ b/src/components/common/FollowList/hooks/useFollowQuery.ts
@@ -1,0 +1,23 @@
+import { FollowListProps } from '@/components/common/FollowList/FollowList'
+import { INITIAL_PAGE_NUMBER, PAGE_SIZE } from '@/constants'
+import { useInfiniteQuery } from '@tanstack/react-query'
+
+const useFollowQuery = ({ memberId, fetchFn, type }: FollowListProps) => {
+  const queryKey = type === 'following' || 'follower'
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
+    queryKey: [queryKey, memberId],
+    queryFn: ({ pageParam }) =>
+      fetchFn({
+        memberId,
+        pageNumber: pageParam,
+        pageSize: PAGE_SIZE,
+      }),
+    initialPageParam: INITIAL_PAGE_NUMBER,
+    getNextPageParam: (lastPage) =>
+      lastPage.metaData?.hasNext ? lastPage.metaData.pageNumber + 1 : undefined,
+  })
+
+  return { followList: data, fetchNextPage, hasNextPage }
+}
+
+export default useFollowQuery

--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -54,7 +54,7 @@ const LinkItem = ({
   const { isLoggedIn } = useCurrentUser()
   const { Modal, isOpen, modalClose, currentModal, handleOpenCurrentModal } =
     useModal()
-  const { isLiked, likeCount, handleLikeClick } = useLikeLink({
+  const { isLiked, likeCount, handleClickLike } = useLikeLink({
     linkId,
     isLikedValue: isInitLiked,
     likeCountValue: likeInitCount,
@@ -113,7 +113,7 @@ const LinkItem = ({
                   className="button button-round button-white"
                   onClick={() =>
                     isLoggedIn
-                      ? handleLikeClick(isLiked)
+                      ? handleClickLike(isLiked)
                       : handleOpenCurrentModal('login')
                   }>
                   {isLiked ? (
@@ -183,7 +183,7 @@ const LinkItem = ({
                   className="button button-round button-white"
                   onClick={() =>
                     isLoggedIn
-                      ? handleLikeClick(isLiked)
+                      ? handleClickLike(isLiked)
                       : handleOpenCurrentModal('login')
                   }>
                   {isLiked ? (

--- a/src/components/common/LinkItem/hooks/useLikeLink.ts
+++ b/src/components/common/LinkItem/hooks/useLikeLink.ts
@@ -33,7 +33,7 @@ const useLikeLink = ({
     [linkId],
   )
 
-  const handleLikeClick = useCallback(
+  const handleClickLike = useCallback(
     (isLike: boolean) => {
       likeToggle()
       if (isLike) {
@@ -47,7 +47,7 @@ const useLikeLink = ({
     [likeToggle, debounceUnLikeLink, debounceLikeLink],
   )
 
-  return { isLiked, likeCount, handleLikeClick }
+  return { isLiked, likeCount, handleClickLike }
 }
 
 export default useLikeLink

--- a/src/components/common/Space/Space.tsx
+++ b/src/components/common/Space/Space.tsx
@@ -41,7 +41,7 @@ const Space = ({
   onClickScrap,
 }: SpaceProps) => {
   const { isLoggedIn } = useCurrentUser()
-  const { isFavorites, favoritesCount, handleFavoriteClick } = useFavorites({
+  const { isFavorites, favoritesCount, handleClickFavorite } = useFavorites({
     spaceId,
     hasFavorite,
     favorite,
@@ -123,7 +123,7 @@ const Space = ({
               <Button
                 className="button button-round button-white"
                 onClick={() => {
-                  isLoggedIn ? handleFavoriteClick(isFavorites) : modalOpen()
+                  isLoggedIn ? handleClickFavorite(isFavorites) : modalOpen()
                 }}>
                 {isFavorites ? (
                   <StarIconSolid className="h-4 w-4 text-yellow-300" />

--- a/src/components/common/Space/hooks/useFavorites.ts
+++ b/src/components/common/Space/hooks/useFavorites.ts
@@ -36,7 +36,7 @@ const useFavorites = ({
     [spaceId],
   )
 
-  const handleFavoriteClick = useCallback(
+  const handleClickFavorite = useCallback(
     (isFavorites: boolean) => {
       favoritesToggle()
       if (isFavorites) {
@@ -50,7 +50,7 @@ const useFavorites = ({
     [favoritesToggle, debounceUnFetchSpace, debouncefetchSpace],
   )
 
-  return { isFavorites, favoritesCount, handleFavoriteClick }
+  return { isFavorites, favoritesCount, handleClickFavorite }
 }
 
 export default useFavorites

--- a/src/components/common/User/User.tsx
+++ b/src/components/common/User/User.tsx
@@ -1,9 +1,13 @@
 'use client'
 
+import { Dispatch, SetStateAction } from 'react'
+import { PROFILE_MSG } from '@/constants'
+import { useFollowUser, useModal } from '@/hooks'
 import { cls } from '@/utils'
 import Link from 'next/link'
 import Avatar from '../Avatar/Avatar'
 import Button from '../Button/Button'
+import LoginModal from '../Modal/LoginModal'
 
 interface UserProps {
   memberId?: number
@@ -12,7 +16,9 @@ interface UserProps {
   aboutMe?: string
   isFollowing?: boolean
   isAuth?: boolean
-  onClick?: (isFollowing: boolean) => void
+  followingCount?: number
+  myId?: number
+  setFollowingCount?: Dispatch<SetStateAction<number | undefined>>
 }
 
 const User = ({
@@ -22,46 +28,73 @@ const User = ({
   aboutMe,
   isFollowing,
   isAuth,
-  onClick,
+  followingCount,
+  myId,
+  setFollowingCount,
 }: UserProps) => {
-  const handleFollowButtonClick = () => {
-    onClick?.(!!isFollowing)
-  }
+  const { Modal, isOpen, modalClose, currentModal, handleOpenCurrentModal } =
+    useModal()
+  const { isFollowing: isFollowingValue, handleClickListInFollow } =
+    useFollowUser({
+      memberId: memberId || 0,
+      isInitFollowing: !!isFollowing,
+      followerInitCount: followingCount || 0,
+    })
 
   return (
-    <div className="flex items-center gap-x-3 rounded-md border border-slate3 p-3">
-      <div className="inline-flex shrink-0">
-        <Avatar
-          src={profileImagePath}
-          width={40}
-          height={40}
-          alt="profile"
-        />
-      </div>
-      <div className="flex grow flex-col gap-y-0.5 overflow-hidden py-0.5">
-        <Link
-          href={`/user/${memberId}`}
-          className="block overflow-hidden text-ellipsis whitespace-nowrap text-sm font-bold text-gray9">
-          {nickname}
-        </Link>
-        <p className="overflow-hidden text-ellipsis whitespace-nowrap text-xs text-gray6">
-          {aboutMe}
-        </p>
-      </div>
-      {!isAuth && (
-        <div className="shrink-0">
-          <Button
-            type="button"
-            className={cls(
-              'button px-2.5 py-1.5 text-sm',
-              isFollowing ? 'button-white' : 'button-emerald',
-            )}
-            onClick={handleFollowButtonClick}>
-            {isFollowing ? '팔로잉' : '팔로우'}
-          </Button>
+    <>
+      <div className="flex items-center gap-x-3 rounded-md border border-slate3 p-3">
+        <div className="inline-flex shrink-0">
+          <Avatar
+            src={profileImagePath}
+            width={40}
+            height={40}
+            alt="profile"
+          />
         </div>
+        <div className="flex grow flex-col gap-y-0.5 overflow-hidden py-0.5">
+          <Link
+            href={`/user/${memberId}`}
+            className="block overflow-hidden text-ellipsis whitespace-nowrap text-sm font-bold text-gray9">
+            {nickname}
+          </Link>
+          <p className="overflow-hidden text-ellipsis whitespace-nowrap text-xs text-gray6">
+            {aboutMe}
+          </p>
+        </div>
+        {!isAuth && (
+          <div className="shrink-0">
+            <Button
+              type="button"
+              className={cls(
+                'button px-2.5 py-1.5 text-sm',
+                isFollowingValue ? 'button-white' : 'button-emerald',
+              )}
+              onClick={() => {
+                if (myId) {
+                  handleClickListInFollow(isFollowingValue)
+                  if (isFollowingValue) {
+                    setFollowingCount?.((prev) => prev! - 1)
+                  } else {
+                    setFollowingCount?.((prev) => prev! + 1)
+                  }
+                } else {
+                  handleOpenCurrentModal('login')
+                }
+              }}>
+              {isFollowingValue ? PROFILE_MSG.FOLLOWING : PROFILE_MSG.FOLLOW}
+            </Button>
+          </div>
+        )}
+      </div>
+      {currentModal === 'login' && (
+        <LoginModal
+          Modal={Modal}
+          isOpen={isOpen}
+          modalClose={modalClose}
+        />
       )}
-    </div>
+    </>
   )
 }
 

--- a/src/components/common/User/User.tsx
+++ b/src/components/common/User/User.tsx
@@ -18,6 +18,7 @@ interface UserProps {
   isAuth?: boolean
   followingCount?: number
   myId?: number
+  profileId?: number
   setFollowingCount?: Dispatch<SetStateAction<number | undefined>>
 }
 
@@ -30,6 +31,7 @@ const User = ({
   isAuth,
   followingCount,
   myId,
+  profileId,
   setFollowingCount,
 }: UserProps) => {
   const { Modal, isOpen, modalClose, currentModal, handleOpenCurrentModal } =
@@ -74,9 +76,11 @@ const User = ({
                 if (myId) {
                   handleClickListInFollow(isFollowingValue)
                   if (isFollowingValue) {
-                    setFollowingCount?.((prev) => prev! - 1)
+                    profileId === myId &&
+                      setFollowingCount?.((prev) => prev! - 1)
                   } else {
-                    setFollowingCount?.((prev) => prev! + 1)
+                    profileId === myId &&
+                      setFollowingCount?.((prev) => prev! + 1)
                   }
                 } else {
                   handleOpenCurrentModal('login')

--- a/src/components/common/User/User.tsx
+++ b/src/components/common/User/User.tsx
@@ -4,52 +4,48 @@ import { cls } from '@/utils'
 import Link from 'next/link'
 import Avatar from '../Avatar/Avatar'
 import Button from '../Button/Button'
-import useToggle from '../Toggle/hooks/useToggle'
 
 interface UserProps {
-  id: number
-  name: string
-  profile: string
-  oneLiner?: string
-  isFollow?: boolean
+  memberId?: number
+  nickname: string
+  profileImagePath: string
+  aboutMe?: string
+  isFollowing?: boolean
   isAuth?: boolean
-  onClick?: (id: number, isFollow: boolean) => void
+  onClick?: (isFollowing: boolean) => void
 }
 
 const User = ({
-  id,
-  name,
-  profile,
-  oneLiner,
-  isFollow,
+  memberId,
+  nickname,
+  profileImagePath,
+  aboutMe,
+  isFollowing,
   isAuth,
   onClick,
 }: UserProps) => {
-  const [isFollowing, toggle] = useToggle(isFollow)
-
-  const handleButtonClick = () => {
-    toggle()
-    onClick?.(id, isFollowing)
+  const handleFollowButtonClick = () => {
+    onClick?.(!!isFollowing)
   }
 
   return (
     <div className="flex items-center gap-x-3 rounded-md border border-slate3 p-3">
       <div className="inline-flex shrink-0">
         <Avatar
-          src={profile}
+          src={profileImagePath}
           width={40}
           height={40}
-          alt={name}
+          alt="profile"
         />
       </div>
       <div className="flex grow flex-col gap-y-0.5 overflow-hidden py-0.5">
         <Link
-          href={`/user/${id}`}
+          href={`/user/${memberId}`}
           className="block overflow-hidden text-ellipsis whitespace-nowrap text-sm font-bold text-gray9">
-          {name}
+          {nickname}
         </Link>
         <p className="overflow-hidden text-ellipsis whitespace-nowrap text-xs text-gray6">
-          {oneLiner}
+          {aboutMe}
         </p>
       </div>
       {!isAuth && (
@@ -60,7 +56,7 @@ const User = ({
               'button px-2.5 py-1.5 text-sm',
               isFollowing ? 'button-white' : 'button-emerald',
             )}
-            onClick={handleButtonClick}>
+            onClick={handleFollowButtonClick}>
             {isFollowing ? '팔로잉' : '팔로우'}
           </Button>
         </div>

--- a/src/hooks/useFollowUser.ts
+++ b/src/hooks/useFollowUser.ts
@@ -9,23 +9,30 @@ import { useCurrentUser } from './useCurrentUser'
 export interface UseFollowUserProps {
   memberId: number
   isInitFollowing: boolean
+  followingInitCount?: number
   followerInitCount: number
-  handleOpenCurrentModal: (current: string) => void
+  handleOpenCurrentModal?: (current: string) => void
 }
 
 const useFollowUser = ({
   memberId,
   isInitFollowing,
   followerInitCount,
+  followingInitCount,
   handleOpenCurrentModal,
 }: UseFollowUserProps) => {
   const { isLoggedIn } = useCurrentUser()
   const [isFollowing, setIsFollowing] = useState(isInitFollowing)
+  const [followingCount, setFollowingCount] = useState(followingInitCount)
   const [followerCount, setFollowerCount] = useState(followerInitCount)
 
   useEffect(() => {
     setIsFollowing(isInitFollowing)
   }, [isInitFollowing])
+
+  useEffect(() => {
+    setFollowingCount(followingInitCount)
+  }, [followingInitCount])
 
   useEffect(() => {
     setFollowerCount(followerInitCount)
@@ -63,7 +70,7 @@ const useFollowUser = ({
           debounceFollowUser()
         }
       } else {
-        handleOpenCurrentModal('login')
+        handleOpenCurrentModal?.('login')
       }
     },
     [
@@ -74,7 +81,26 @@ const useFollowUser = ({
     ],
   )
 
-  return { isFollowing, followerCount, handleClickFollow }
+  const handleClickListInFollow = useCallback(
+    (isFollowing: boolean) => {
+      setIsFollowing((prev) => !prev)
+      if (isFollowing) {
+        debounceUnFollowUser()
+      } else {
+        debounceFollowUser()
+      }
+    },
+    [debounceUnFollowUser, debounceFollowUser],
+  )
+
+  return {
+    isFollowing,
+    followingCount,
+    setFollowingCount,
+    followerCount,
+    handleClickFollow,
+    handleClickListInFollow,
+  }
 }
 
 export default useFollowUser

--- a/src/hooks/useFollowUser.ts
+++ b/src/hooks/useFollowUser.ts
@@ -51,7 +51,7 @@ const useFollowUser = ({
     [memberId],
   )
 
-  const handleFollowClick = useCallback(
+  const handleClickFollow = useCallback(
     (isFollowing: boolean) => {
       if (isLoggedIn) {
         setIsFollowing((prev) => !prev)
@@ -74,7 +74,7 @@ const useFollowUser = ({
     ],
   )
 
-  return { isFollowing, followerCount, handleFollowClick }
+  return { isFollowing, followerCount, handleClickFollow }
 }
 
 export default useFollowUser

--- a/src/lib/fetchAPI.ts
+++ b/src/lib/fetchAPI.ts
@@ -10,18 +10,22 @@ class FetchAPI {
       'Content-Type': 'application/json;charset=UTF-8',
     }
   }
+
   public static getInstance(): FetchAPI {
     if (!FetchAPI.instance) {
       FetchAPI.instance = new FetchAPI()
     }
     return FetchAPI.instance
   }
+
   public setBaseURL(url: string): void {
     this.baseURL = url
   }
+
   public setDefaultHeader(key: string, value: string): void {
     this.headers[key] = value
   }
+
   public async get(
     endpoint: string,
     nextInit: RequestInit = {},
@@ -35,6 +39,7 @@ class FetchAPI {
     const data = response.json()
     return data
   }
+
   public async post(
     endpoint: string,
     body: any,
@@ -54,6 +59,7 @@ class FetchAPI {
     const data = response.json()
     return data
   }
+
   public async put(
     endpoint: string,
     body: any,
@@ -73,6 +79,7 @@ class FetchAPI {
     const data = response.json()
     return data
   }
+
   public async delete(
     endpoint: string,
     nextInit: RequestInit = {},
@@ -85,6 +92,7 @@ class FetchAPI {
     })
     return response
   }
+
   public async patch(
     endpoint: string,
     body: any,
@@ -104,4 +112,5 @@ class FetchAPI {
     return response
   }
 }
+
 export default FetchAPI

--- a/src/lib/fetchServerAPI.ts
+++ b/src/lib/fetchServerAPI.ts
@@ -10,18 +10,22 @@ class FetchServerAPI {
       'Content-Type': 'application/json;charset=UTF-8',
     }
   }
+
   public static getInstance(): FetchServerAPI {
     if (!FetchServerAPI.instance) {
       FetchServerAPI.instance = new FetchServerAPI()
     }
     return FetchServerAPI.instance
   }
+
   public setBaseURL(url: string): void {
     this.baseURL = url
   }
+
   public setDefaultHeader(key: string, value: string): void {
     this.headers[key] = value
   }
+
   public async get(
     endpoint: string,
     nextInit: RequestInit = {},
@@ -35,13 +39,14 @@ class FetchServerAPI {
     const data = response.json()
     return data
   }
+
   public async post(
     endpoint: string,
     body: any,
     nextInit: RequestInit = {},
     customHeaders: { [key: string]: string } = {},
     type: string = 'default',
-  ): Promise<any> {
+  ) {
     const response = await fetch(`${this.baseURL}${endpoint}`, {
       method: 'POST',
       headers:
@@ -51,16 +56,16 @@ class FetchServerAPI {
       body: type === 'multipart' ? body : JSON.stringify(body),
       ...nextInit,
     })
-    const data = response.json()
-    return data
+    return response
   }
+
   public async put(
     endpoint: string,
     body: any,
     nextInit: RequestInit = {},
     customHeaders: { [key: string]: string } = {},
     type: string = 'default',
-  ): Promise<any> {
+  ) {
     const response = await fetch(`${this.baseURL}${endpoint}`, {
       method: 'PUT',
       headers:
@@ -70,29 +75,29 @@ class FetchServerAPI {
       body: type === 'multipart' ? body : JSON.stringify(body),
       ...nextInit,
     })
-    const data = response.json()
-    return data
+    return response
   }
+
   public async delete(
     endpoint: string,
     nextInit: RequestInit = {},
     customHeaders: { [key: string]: string } = {},
-  ): Promise<any> {
+  ) {
     const response = await fetch(`${this.baseURL}${endpoint}`, {
       method: 'DELETE',
       headers: { ...this.headers, ...customHeaders },
       ...nextInit,
     })
-    const data = response
-    return data
+    return response
   }
+
   public async patch(
     endpoint: string,
     body: any,
     nextInit: RequestInit = {},
     customHeaders: { [key: string]: string } = {},
     type: string = 'default',
-  ): Promise<any> {
+  ) {
     const response = await fetch(`${this.baseURL}${endpoint}`, {
       method: 'PATCH',
       headers:
@@ -105,4 +110,5 @@ class FetchServerAPI {
     return response
   }
 }
+
 export default FetchServerAPI

--- a/src/services/user/follow/route.ts
+++ b/src/services/user/follow/route.ts
@@ -1,5 +1,55 @@
 import { apiClient } from '@/services/apiServices'
 
+export interface FetchGetFollowingProps {
+  memberId: number
+  pageNumber: number
+  pageSize: number
+}
+
+const fetchGetFollowing = async ({
+  memberId,
+  pageNumber,
+  pageSize,
+}: FetchGetFollowingProps) => {
+  const path = `/api/user/following`
+  const params = {
+    memberId: memberId.toString(),
+    pageNumber: pageNumber.toString(),
+    pageSize: pageSize.toString(),
+  }
+  const queryString = new URLSearchParams(params).toString()
+
+  try {
+    const response = await apiClient.get(`${path}?${queryString}`)
+    return response
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
+}
+
+export interface FetchGetFollowersProps extends FetchGetFollowingProps {}
+
+const fetchGetFollowers = async ({
+  memberId,
+  pageNumber,
+  pageSize,
+}: FetchGetFollowersProps) => {
+  const path = `/api/user/followers`
+  const params = {
+    memberId: memberId.toString(),
+    pageNumber: pageNumber.toString(),
+    pageSize: pageSize.toString(),
+  }
+  const queryString = new URLSearchParams(params).toString()
+
+  try {
+    const response = await apiClient.get(`${path}?${queryString}`)
+    return response
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
+}
+
 export interface FetchFollowUserProps {
   memberId: number
 }
@@ -34,4 +84,9 @@ const fetchUnFollowUser = async ({ memberId }: FetchFollowUserProps) => {
   }
 }
 
-export { fetchFollowUser, fetchUnFollowUser }
+export {
+  fetchGetFollowing,
+  fetchGetFollowers,
+  fetchFollowUser,
+  fetchUnFollowUser,
+}

--- a/src/services/user/follow/route.ts
+++ b/src/services/user/follow/route.ts
@@ -1,7 +1,7 @@
 import { apiClient } from '@/services/apiServices'
 
-export interface FetchGetFollowingProps {
-  memberId: number
+export interface FetchGetFollowProps {
+  memberId?: number
   pageNumber: number
   pageSize: number
 }
@@ -10,7 +10,7 @@ const fetchGetFollowing = async ({
   memberId,
   pageNumber,
   pageSize,
-}: FetchGetFollowingProps) => {
+}: FetchGetFollowProps) => {
   const path = `/api/user/${memberId}/following`
   const params = {
     pageNumber: pageNumber.toString(),
@@ -26,13 +26,11 @@ const fetchGetFollowing = async ({
   }
 }
 
-export interface FetchGetFollowersProps extends FetchGetFollowingProps {}
-
 const fetchGetFollowers = async ({
   memberId,
   pageNumber,
   pageSize,
-}: FetchGetFollowersProps) => {
+}: FetchGetFollowProps) => {
   const path = `/api/user/${memberId}/followers`
   const params = {
     pageNumber: pageNumber.toString(),

--- a/src/services/user/follow/route.ts
+++ b/src/services/user/follow/route.ts
@@ -11,9 +11,8 @@ const fetchGetFollowing = async ({
   pageNumber,
   pageSize,
 }: FetchGetFollowingProps) => {
-  const path = `/api/user/following`
+  const path = `/api/user/${memberId}/following`
   const params = {
-    memberId: memberId.toString(),
     pageNumber: pageNumber.toString(),
     pageSize: pageSize.toString(),
   }
@@ -34,9 +33,8 @@ const fetchGetFollowers = async ({
   pageNumber,
   pageSize,
 }: FetchGetFollowersProps) => {
-  const path = `/api/user/followers`
+  const path = `/api/user/${memberId}/followers`
   const params = {
-    memberId: memberId.toString(),
     pageNumber: pageNumber.toString(),
     pageSize: pageSize.toString(),
   }


### PR DESCRIPTION
## 📑 이슈 번호
#140 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 팔로잉 목록 조회 api를 연결 및 구현하였습니다.
- 팔로워 목록 조회 api를 연결 및 구현하였습니다.
- 무한 스크롤로 10개씩 페이지네이션 하였습니다.
   (유저가 많이 없어서 page size를 3개로 설정한 후 확인해 보았습니다.)
- 본인의 프로필에서 팔로우 리스트를 클릭 후 팔로우 버튼을 누르면 count가 즉각적으로 바뀌도록 구현하였습니다.

### 로그인 한 유저가 팔로우 버튼을 눌렀을 때
![Nov-23-2023 14-32-19](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/e41816e0-14ab-488a-8a85-84c8a9d6bacc)

<br>

### 로그인하지 않은 유저가 팔로우 버튼을 눌렀을 때
![Nov-23-2023 16-27-04](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/a5afc18e-5261-48be-999f-21dfa3903468)


## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### fetchServerAPI 변경점
GET 메소드를 제외한 모든 API 함수의 response 형식을 변경하였습니다.
```tsx
public async post(
    endpoint: string,
    body: any,
    nextInit: RequestInit = {},
    customHeaders: { [key: string]: string } = {},
    type: string = 'default',
  ) {
    const response = await fetch(`${this.baseURL}${endpoint}`, {
      method: 'POST',
      headers:
        type === 'multipart'
          ? { ...customHeaders }
          : { ...this.headers, ...customHeaders },
      body: type === 'multipart' ? body : JSON.stringify(body),
      ...nextInit,
    })
    return response
  }
```

<br>

### Next API 데이터 return 작성법

반환값이 존재하는 API는 아래 형식으로 작성
```tsx
const response = await apiServer.post(path, {}, {}, headers)
const data = await response.json()
return NextResponse.json(data)
```

반환값이 존재하지 않는 API는 아래 형식으로 작성
```tsx
const data = await apiServer.delete(path, {}, headers)
return NextResponse.json(data)
```
<br>

API 재호출 후 값이 변할 때 이전 값이 일시적으로 보여서 추후에 로딩 기능은 필수로 구현해야겠습니다!