### PR TITLE
댓글 삭제 api 연결

### DIFF
--- a/src/app/(routes)/space/[spaceId]/comment/page.tsx
+++ b/src/app/(routes)/space/[spaceId]/comment/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Fragment } from 'react'
 import { useForm } from 'react-hook-form'
 import { Input } from '@/components'
 import CommentList from '@/components/CommentList/CommentList'
@@ -11,7 +10,6 @@ import Tab from '@/components/common/Tab/Tab'
 import TabItem from '@/components/common/Tab/TabItem'
 import useTab from '@/components/common/Tab/hooks/useTab'
 import { CATEGORIES_RENDER, MIN_TAB_NUMBER } from '@/constants'
-import { useModal } from '@/hooks'
 import useSpaceComment from '@/hooks/useSpaceComment'
 import { fetchGetComments } from '@/services/comment/comment'
 import { XMarkIcon } from '@heroicons/react/20/solid'
@@ -22,7 +20,6 @@ export interface CommentFormValues {
 
 const SpaceCommentPage = ({ params }: { params: { spaceId: number } }) => {
   const [space] = useGetSpace()
-  const { Modal, isOpen, modalOpen, modalClose } = useModal(false)
   const { register, setValue, setFocus, handleSubmit } =
     useForm<CommentFormValues>({
       defaultValues: {
@@ -33,17 +30,13 @@ const SpaceCommentPage = ({ params }: { params: { spaceId: number } }) => {
     comment,
     commentListRef,
     handleEdit,
-    handleDelete,
-    handleOpen,
     handleReply,
-    handleDeleteConfirm,
     handleReplyCancel,
     onSubmit,
   } = useSpaceComment({
     spaceId: params.spaceId,
     setValue,
     setFocus,
-    modalOpen,
   })
   const { currentTab, tabList } = useTab({ type: 'space', space })
 
@@ -107,18 +100,6 @@ const SpaceCommentPage = ({ params }: { params: { spaceId: number } }) => {
           />
         </div>
       </form>
-      {isOpen && (
-        <Modal
-          title="댓글 삭제"
-          isCancelButton={true}
-          isConfirmButton={true}
-          cancelText="취소"
-          confirmText="삭제"
-          onClose={modalClose}
-          onConfirm={handleDeleteConfirm}>
-          <div className="flex justify-center">삭제하시겠습니까?</div>
-        </Modal>
-      )}
     </>
   )
 }

--- a/src/app/api/space/[spaceId]/comments/[commentId]/route.ts
+++ b/src/app/api/space/[spaceId]/comments/[commentId]/route.ts
@@ -1,0 +1,25 @@
+import { useServerCookie } from '@/hooks/useServerCookie'
+import { apiServer } from '@/services/apiServices'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { spaceId: number; commentId: number } },
+) {
+  const { token } = useServerCookie()
+  const { spaceId, commentId } = params
+  const path = `/spaces/${spaceId}/comments/${commentId}`
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  }
+
+  try {
+    const data = await apiServer.delete(path, {}, headers)
+    return NextResponse.json(data)
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.message },
+      { status: error.response.status },
+    )
+  }
+}

--- a/src/components/CommentList/CommentList.tsx
+++ b/src/components/CommentList/CommentList.tsx
@@ -39,6 +39,7 @@ const CommentList = ({ spaceId, fetchFn }: CommentListProps) => {
                 <li key={comment.commentId}>
                   <Comment
                     commentId={comment.commentId}
+                    spaceId={spaceId}
                     user={{
                       id: comment.memberId,
                       name: comment.nickname,
@@ -50,7 +51,6 @@ const CommentList = ({ spaceId, fetchFn }: CommentListProps) => {
                     replyCount={comment.childCount}
                     auth={comment.isModifiable}
                     onEdit={() => {}}
-                    onDelete={() => {}}
                     onOpen={() => handleOpen(groupIdx, commentIdx)}
                     onReply={() => {}}
                   />

--- a/src/components/ReplyList/ReplyList.tsx
+++ b/src/components/ReplyList/ReplyList.tsx
@@ -32,6 +32,8 @@ const ReplyList = ({ spaceId, commentId, fetchFn }: ReplyListProps) => {
                     name: comment.nickname,
                     profile: comment.profileImagePath,
                   }}
+                  spaceId={spaceId}
+                  parentCommentId={comment.parentCommentId}
                   comment={comment.content}
                   firstDepth={false}
                   date={new Date(comment.createdAt)}

--- a/src/components/common/Comment/Comment.tsx
+++ b/src/components/common/Comment/Comment.tsx
@@ -1,24 +1,31 @@
+'use client'
+
+import { useModal } from '@/hooks'
 import { PencilSquareIcon, TrashIcon } from '@heroicons/react/24/outline'
 import Link from 'next/link'
 import { Avatar } from '../..'
 import Button from '../Button/Button'
+import useComment from './hooks/useComment'
 
 export interface CommentProps {
   commentId: number
+  spaceId: number
   user: { id: number; name: string; profile: string }
   comment: string
   date: Date
   auth?: boolean
   firstDepth?: boolean
+  parentCommentId?: number
   replyCount?: number
   onEdit?: (commentId: number, comment: string) => void
-  onDelete?: (commentId: number) => void
   onOpen?: (commentId: number) => void
   onReply?: (commentId: number, userName: string) => void
 }
 
 const Comment = ({
   commentId,
+  spaceId,
+  parentCommentId,
   user,
   comment,
   date,
@@ -26,63 +33,83 @@ const Comment = ({
   firstDepth = true,
   replyCount = 0,
   onEdit,
-  onDelete,
   onOpen,
   onReply,
 }: CommentProps) => {
+  const { Modal, isOpen, modalOpen, modalClose } = useModal(false)
+  const { handleDelete, handleDeleteConfirm } = useComment({
+    spaceId,
+    parentCommentId,
+    modalOpen,
+  })
+
   return (
-    <article className="flex gap-x-2 py-3">
-      <Avatar
-        src={user.profile}
-        width={30}
-        height={30}
-        alt={user.name}
-      />
-      <div className="flex w-full flex-col gap-y-1">
-        <div className="flex items-center justify-between">
-          <Link
-            href={`/user/${user.id}`}
-            className="text-sm font-semibold text-gray9">
-            {user.name}
-          </Link>
-          {auth && onEdit && onDelete && (
-            <div className="flex gap-x-1.5">
-              <Button
-                className="p-0.5"
-                onClick={() => onDelete(commentId)}>
-                <TrashIcon className="h-5 w-5 text-slate6" />
-              </Button>
-              <Button
-                className="p-0.5"
-                onClick={() => onEdit(commentId, comment)}>
-                <PencilSquareIcon className="h-5 w-5 text-slate6" />
-              </Button>
-            </div>
-          )}
+    <>
+      <article className="flex gap-x-2 py-3">
+        <Avatar
+          src={user.profile}
+          width={30}
+          height={30}
+          alt={user.name}
+        />
+        <div className="flex w-full flex-col gap-y-1">
+          <div className="flex items-center justify-between">
+            <Link
+              href={`/user/${user.id}`}
+              className="text-sm font-semibold text-gray9">
+              {user.name}
+            </Link>
+            {auth && (
+              <div className="flex gap-x-1.5">
+                <Button
+                  className="p-0.5"
+                  onClick={() => handleDelete(commentId)}>
+                  <TrashIcon className="h-5 w-5 text-slate6" />
+                </Button>
+                <Button
+                  className="p-0.5"
+                  onClick={() => onEdit && onEdit(commentId, comment)}>
+                  <PencilSquareIcon className="h-5 w-5 text-slate6" />
+                </Button>
+              </div>
+            )}
+          </div>
+          <p className="py-1 text-sm text-gray9">{comment}</p>
+          <div className="pt-1 text-xs text-gray6">
+            {date.getFullYear().toString()}.{(date.getMonth() + 1).toString()}.
+            {date.getDate().toString()}
+            {firstDepth && (
+              <>
+                {' • '}
+                <Button
+                  className="font-medium"
+                  onClick={() => replyCount > 0 && onOpen && onOpen(commentId)}>
+                  {replyCount}개의 답글
+                </Button>
+                {' • '}
+                <Button
+                  className="font-medium"
+                  onClick={() => onReply && onReply(commentId, user.name)}>
+                  답글 달기
+                </Button>
+              </>
+            )}
+          </div>
         </div>
-        <p className="py-1 text-sm text-gray9">{comment}</p>
-        <div className="pt-1 text-xs text-gray6">
-          {date.getFullYear().toString()}.{(date.getMonth() + 1).toString()}.
-          {date.getDate().toString()}
-          {firstDepth && (
-            <>
-              {' • '}
-              <Button
-                className="font-medium"
-                onClick={() => replyCount > 0 && onOpen && onOpen(commentId)}>
-                {replyCount}개의 답글
-              </Button>
-              {' • '}
-              <Button
-                className="font-medium"
-                onClick={() => onReply && onReply(commentId, user.name)}>
-                답글 달기
-              </Button>
-            </>
-          )}
-        </div>
-      </div>
-    </article>
+      </article>
+      {isOpen && (
+        <Modal
+          title="댓글 삭제"
+          isCancelButton={true}
+          isConfirmButton={true}
+          cancelText="취소"
+          confirmText="삭제"
+          onClose={modalClose}
+          onConfirm={() => handleDeleteConfirm(!firstDepth)}>
+          <div className="flex justify-center">삭제하시겠습니까?</div>
+        </Modal>
+      )}
+    </>
   )
 }
 

--- a/src/components/common/Comment/hooks/useComment.ts
+++ b/src/components/common/Comment/hooks/useComment.ts
@@ -1,0 +1,46 @@
+import { useCallback, useState } from 'react'
+import { fetchDeleteComment } from '@/services/comment/comment'
+import { useQueryClient } from '@tanstack/react-query'
+
+export interface useCommentProps {
+  spaceId: number
+  parentCommentId?: number
+  modalOpen: VoidFunction
+}
+
+const useComment = ({
+  spaceId,
+  parentCommentId,
+  modalOpen,
+}: useCommentProps) => {
+  const queryClient = useQueryClient()
+  const [deleteCommentId, setDeleteCommentId] = useState(0)
+
+  const handleDelete = useCallback(
+    (commentId: number) => {
+      setDeleteCommentId(commentId)
+      modalOpen()
+    },
+    [modalOpen],
+  )
+
+  const handleDeleteConfirm = useCallback(
+    async (isReply: boolean) => {
+      await fetchDeleteComment(spaceId, deleteCommentId)
+      await queryClient.invalidateQueries({ queryKey: ['comments', spaceId] })
+      if (isReply) {
+        await queryClient.invalidateQueries({
+          queryKey: ['replies', spaceId, parentCommentId],
+        })
+      }
+    },
+    [deleteCommentId, queryClient, spaceId, parentCommentId],
+  )
+
+  return {
+    handleDelete,
+    handleDeleteConfirm,
+  }
+}
+
+export default useComment

--- a/src/hooks/useSpaceComment.ts
+++ b/src/hooks/useSpaceComment.ts
@@ -6,7 +6,6 @@ import {
 } from 'react-hook-form'
 import { CommentFormValues } from '@/app/(routes)/space/[spaceId]/comment/page'
 import { CommentProps } from '@/components/common/Comment/Comment'
-import { mock_commentData, mock_replyData } from '@/data'
 import { fetchCreateComment } from '@/services/comment/comment'
 import { useQueryClient } from '@tanstack/react-query'
 
@@ -18,11 +17,10 @@ export interface useSpaceCommentProps {
   spaceId: number
   setValue: UseFormSetValue<CommentFormValues>
   setFocus: UseFormSetFocus<CommentFormValues>
-  modalOpen: () => void
 }
 
 export interface Comment {
-  type: 'create' | 'edit' | 'reply' | 'delete'
+  type: 'create' | 'edit' | 'reply'
   commentId: number
   userName?: string
 }
@@ -36,10 +34,8 @@ const useSpaceComment = ({
   spaceId,
   setValue,
   setFocus,
-  modalOpen,
 }: useSpaceCommentProps) => {
   const queryClient = useQueryClient()
-  const [comments, setComments] = useState<SpaceComment[]>(mock_commentData)
   const [comment, setComment] = useState<Comment>(defaultComment)
   const commentListRef = useRef<HTMLDivElement>(null)
 
@@ -52,29 +48,6 @@ const useSpaceComment = ({
     [setFocus, setValue],
   )
 
-  const handleDelete = useCallback(
-    (commentId: number) => {
-      setComment({ type: 'delete', commentId })
-      modalOpen()
-    },
-    [modalOpen],
-  )
-
-  const handleOpen = useCallback(
-    (commentId: number) => {
-      const commentsWithReplies = comments.map((comment) =>
-        comment.commentId === commentId
-          ? {
-              ...comment,
-              replies: mock_replyData,
-            }
-          : comment,
-      )
-      setComments(commentsWithReplies)
-    },
-    [comments],
-  )
-
   const handleReply = useCallback(
     (commentId: number, userName: string) => {
       setComment({ type: 'reply', commentId, userName })
@@ -83,10 +56,6 @@ const useSpaceComment = ({
     },
     [setFocus, setValue],
   )
-
-  const handleDeleteConfirm = () => {
-    console.log(comment.type, comment.commentId)
-  }
 
   const handleReplyCancel = () => {
     setComment(defaultComment)
@@ -104,14 +73,10 @@ const useSpaceComment = ({
   }
 
   return {
-    comments,
     comment,
     commentListRef,
     handleEdit,
-    handleDelete,
-    handleOpen,
     handleReply,
-    handleDeleteConfirm,
     handleReplyCancel,
     onSubmit,
   }

--- a/src/services/comment/comment.ts
+++ b/src/services/comment/comment.ts
@@ -36,4 +36,15 @@ const fetchCreateComment = async (
   }
 }
 
-export { fetchGetComments, fetchCreateComment }
+const fetchDeleteComment = async (spaceId: number, commentId: number) => {
+  const path = `/api/space/${spaceId}/comments/${commentId}`
+
+  try {
+    const response = await apiClient.delete(path)
+    return response
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
+}
+
+export { fetchGetComments, fetchCreateComment, fetchDeleteComment }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -198,6 +198,7 @@ export interface CommentResBody {
   nickname: string
   profileImagePath: string
   isModifiable: boolean
+  parentCommentId?: number
 }
 
 export interface CreateCommentReqBody {


### PR DESCRIPTION
## 📑 이슈 번호
- close #144 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 댓글 삭제 api 연결했습니다.
  - 루트 댓글과 대댓글 모두 적용됩니다.

https://github.com/Team-TenTen/LinkHub-FE/assets/49032882/edbe93d8-f116-45e8-8df7-b07efc6e5742

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### Comment 컴포넌트
- Comment 컴포넌트에서 댓글 삭제 로직을 처리하도록 수정했습니다.
  - 댓글 삭제 모달을 컴포넌트로 이동하고, useComment 훅을 구현했습니다.

#### CommentResBody
대댓글 로직 처리를 위해 parentCommentId 프로퍼티를 추가했습니다.