### PR TITLE
유저 검색 api 연결

### DIFF
--- a/src/app/(routes)/search/page.tsx
+++ b/src/app/(routes)/search/page.tsx
@@ -1,21 +1,20 @@
 'use client'
 
 import { CategoryList, Dropdown, SpaceList } from '@/components'
-import User from '@/components/common/User/User'
-import { mock_usersData } from '@/data'
+import UserList from '@/components/UserList/UserList'
 import { useCategoryParam, useSortParam } from '@/hooks'
 import { fetchSearchSpaces } from '@/services/space/spaces'
+import { fetchSearchUsers } from '@/services/user/search/search'
 import { cls } from '@/utils'
 import { useSearchParams } from 'next/navigation'
 
 const SearchPage = () => {
-  const { sort, sortIndex, handleSortChange } = useSortParam('space')
-  const { category, categoryIndex, handleCategoryChange } =
-    useCategoryParam('all')
   const searchParams = useSearchParams()
   const keyword = searchParams.get('keyword')
   const target = searchParams.get('target')
-  const users = mock_usersData
+  const { sort, sortIndex, handleSortChange } = useSortParam('space')
+  const { category, categoryIndex, handleCategoryChange } =
+    useCategoryParam('all')
 
   return (
     <>
@@ -59,15 +58,12 @@ const SearchPage = () => {
             fetchFn={fetchSearchSpaces}
           />
         )}
-        {target === 'user' &&
-          users.map((user) => (
-            <User
-              memberId={user.id}
-              nickname={user.name}
-              profileImagePath={user.profile}
-              key={user.id}
-            />
-          ))}
+        {target === 'user' && (
+          <UserList
+            keyword={keyword ?? ''}
+            fetchFn={fetchSearchUsers}
+          />
+        )}
       </section>
     </>
   )

--- a/src/app/api/user/search/route.ts
+++ b/src/app/api/user/search/route.ts
@@ -1,0 +1,22 @@
+import { useServerCookie } from '@/hooks/useServerCookie'
+import { apiServer } from '@/services/apiServices'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const { token } = useServerCookie()
+  const { searchParams } = new URL(req.url)
+  const path = '/members/search'
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  }
+
+  try {
+    const data = await apiServer.get(`${path}?${searchParams}`, {}, headers)
+    return NextResponse.json(data)
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.errorMessage },
+      { status: error.response.status },
+    )
+  }
+}

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -1,0 +1,53 @@
+import { Fragment } from 'react'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
+import useInfiniteScroll from '@/hooks/useInfiniteScroll'
+import { SearchUserReqBody } from '@/types'
+import User from '../common/User/User'
+import useUsersQuery from './hooks/useUsersQuery'
+
+export interface UserListProps {
+  keyword: string
+  fetchFn: ({ pageNumber, pageSize }: SearchUserReqBody) => Promise<any>
+}
+
+export interface UserItem {
+  isFollowing: boolean
+  memberId: number
+  nickname: string
+  MemberImagePath: string
+  aboutMe: string
+}
+
+const UserList = ({ keyword, fetchFn }: UserListProps) => {
+  const { currentUser } = useCurrentUser()
+  const { users, fetchNextPage, hasNextPage } = useUsersQuery({
+    keyword,
+    fetchFn,
+  })
+  const { target } = useInfiniteScroll({ hasNextPage, fetchNextPage })
+
+  return (
+    <ul className="flex flex-col gap-y-2">
+      {users?.pages.map((group, i) => (
+        <Fragment key={i}>
+          {group.responses?.map((user: UserItem) => (
+            <li key={user.memberId}>
+              <User
+                memberId={user.memberId}
+                nickname={user.nickname}
+                profileImagePath={user.MemberImagePath}
+                aboutMe={user.aboutMe}
+                isFollowing={user.isFollowing}
+                isAuth={currentUser?.memberId === user.memberId}
+                myId={currentUser?.memberId}
+              />
+            </li>
+          ))}
+        </Fragment>
+      ))}
+      <div ref={target}></div>
+    </ul>
+  )
+}
+
+export default UserList

--- a/src/components/UserList/hooks/useUsersQuery.ts
+++ b/src/components/UserList/hooks/useUsersQuery.ts
@@ -1,0 +1,22 @@
+import { INITIAL_PAGE_NUMBER, PAGE_SIZE } from '@/constants'
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { UserListProps } from '../UserList'
+
+const useUsersQuery = ({ keyword, fetchFn }: UserListProps) => {
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
+    queryKey: ['users', keyword],
+    queryFn: ({ pageParam }) =>
+      fetchFn({
+        pageNumber: pageParam,
+        pageSize: PAGE_SIZE,
+        keyword,
+      }),
+    initialPageParam: INITIAL_PAGE_NUMBER,
+    getNextPageParam: (lastPage) =>
+      lastPage.metaData?.hasNext ? lastPage.metaData.pageNumber + 1 : undefined,
+  })
+
+  return { users: data, fetchNextPage, hasNextPage }
+}
+
+export default useUsersQuery

--- a/src/components/common/SearchModal/SearchModal.tsx
+++ b/src/components/common/SearchModal/SearchModal.tsx
@@ -3,8 +3,9 @@
 import { useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { Dropdown } from '@/components'
+import { RocketLaunchIcon } from '@heroicons/react/24/solid'
 import Input from '../Input/Input'
-import { SEARCH_MODAL_TITLE } from './constants'
+import { SEACH_MODAL_INFO, SEARCH_MODAL_TITLE } from './constants'
 import useSearchModal from './hooks/useSearchModal'
 
 export interface SearchModalProps {
@@ -65,16 +66,10 @@ const SearchModal = ({ onClose }: SearchModalProps) => {
           </div>
         </form>
         <h2 className="py-4 font-bold text-gray9">{SEARCH_MODAL_TITLE}</h2>
-        <ul>
-          {trends.map((trend) => (
-            <li
-              className="border-b border-gray3 px-3 py-2.5 text-sm font-medium text-gray9 last:border-none"
-              onClick={handleKeywordClick}
-              key={trend.keyword}>
-              {trend.keyword}
-            </li>
-          ))}
-        </ul>
+        <p className="flex flex-col items-center px-3 py-5 text-center text-sm font-medium text-gray9">
+          <RocketLaunchIcon className="mb-2 h-5 w-5" />
+          {SEACH_MODAL_INFO}
+        </p>
       </div>
     </div>
   )

--- a/src/components/common/SearchModal/constants/index.ts
+++ b/src/components/common/SearchModal/constants/index.ts
@@ -1,1 +1,2 @@
 export const SEARCH_MODAL_TITLE = '인기 검색어'
+export const SEACH_MODAL_INFO = '서비스 준비 중입니다.'

--- a/src/services/user/search/search.ts
+++ b/src/services/user/search/search.ts
@@ -1,0 +1,25 @@
+import { apiClient } from '@/services/apiServices'
+import { SearchUserReqBody } from '@/types'
+
+const fetchSearchUsers = async ({
+  pageNumber,
+  pageSize,
+  keyword,
+}: SearchUserReqBody) => {
+  const path = '/api/user/search'
+  const params = {
+    pageNumber: pageNumber.toString(),
+    pageSize: pageSize.toString(),
+    keyword,
+  }
+  const queryString = new URLSearchParams(params).toString()
+
+  try {
+    const response = await apiClient.get(`${path}?${queryString}`)
+    return response
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
+}
+
+export { fetchSearchUsers }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -214,3 +214,9 @@ export interface CommentResBody {
 export interface CreateCommentReqBody {
   content: string
 }
+
+export interface SearchUserReqBody {
+  pageNumber: number
+  pageSize: number
+  keyword: string
+}


### PR DESCRIPTION
## 📑 이슈 번호
- close #161 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 유저 검색 api 연결했습니다.
- 무한 스크롤을 적용한 UserList 컴포넌트를 구현했습니다.

https://github.com/Team-TenTen/LinkHub-FE/assets/49032882/465ce662-d249-4d19-90e9-55ad41064d59

### UserList 컴포넌트
- useUsersQuery 훅으로 useInfiniteQuery를 제어합니다.

#### props
``` ts
interface UserListProps {
  keyword: string // 📍 useInfiniteQuery에 들어가는 queryKey 옵션으로 유니크한 값
  fetchFn: ({ pageNumber, pageSize }: SearchUserReqBody) => Promise<any> // 📍 유저 검색 fetch 함수
}
```

#### useUsersQuery return
``` ts
return { users: data, fetchNextPage, hasNextPage } // useInfiniteQuery returns
```

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
- 검색 모달 인기 검색어를 준비 중으로 UI 변경했습니다.