### PR TITLE
인기 링크 조회 api 연결

### DIFF
--- a/src/app/api/links/route.ts
+++ b/src/app/api/links/route.ts
@@ -1,0 +1,21 @@
+import { useServerCookie } from '@/hooks/useServerCookie'
+import { apiServer } from '@/services/apiServices'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const { token } = useServerCookie()
+  const path = '/links/popular'
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  }
+
+  try {
+    const data = await apiServer.get(path, {}, headers)
+    return NextResponse.json(data)
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.errorMessage },
+      { status: error.response.status },
+    )
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { CategoryList, Dropdown, LinkItem, SpaceList } from '@/components'
-import { mock_LinkData } from '@/data'
+import { ChipColors } from '@/components/common/Chip/Chip'
 import { useCategoryParam, useSortParam } from '@/hooks'
+import useGetPopularLinks from '@/hooks/useGetPopularLinks'
 import { fetchGetSpaces } from '@/services/space/spaces'
+import { PopularLinkResBody } from '@/types'
 
 export default function Home() {
-  const links = mock_LinkData.slice(0, 5)
+  const links = useGetPopularLinks()
   const { sort, sortIndex, handleSortChange } = useSortParam('space')
   const { category, categoryIndex, handleCategoryChange } =
     useCategoryParam('all_follow')
@@ -15,18 +17,19 @@ export default function Home() {
     <>
       <section className="px-4 pb-10">
         <h2 className="py-4 font-bold text-gray9">인기있는 링크</h2>
-        {links.map((link) => (
-          <LinkItem
-            linkId={link.id}
-            title={link.title}
-            url={link.url}
-            tagName={link.tagName}
-            tagColor="emerald"
-            isInitLiked={link.isLiked}
-            likeInitCount={link.likeCount}
-            key={link.id}
-          />
-        ))}
+        {links &&
+          links.map((link: PopularLinkResBody) => (
+            <LinkItem
+              linkId={link.linkId}
+              title={link.title}
+              url={link.url}
+              tagName={link.tagName}
+              tagColor={link.tagColor as ChipColors}
+              isInitLiked={link.isLiked}
+              likeInitCount={link.likeCount}
+              key={link.linkId}
+            />
+          ))}
       </section>
       <section>
         <div className="sticky top-[53px] z-40 bg-bgColor">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
   const links = useGetPopularLinks()
   const { sort, sortIndex, handleSortChange } = useSortParam('space')
   const { category, categoryIndex, handleCategoryChange } =
-    useCategoryParam('all_follow')
+    useCategoryParam('all')
 
   return (
     <>
@@ -43,7 +43,7 @@ export default function Home() {
             />
           </div>
           <CategoryList
-            type="all_follow"
+            type="all"
             defaultIndex={categoryIndex}
             onChange={handleCategoryChange}
           />

--- a/src/components/SpaceList/SpaceList.tsx
+++ b/src/components/SpaceList/SpaceList.tsx
@@ -50,7 +50,7 @@ const SpaceList = ({
             {group.responses?.map((space: SpaceResBody) => (
               <li key={space.spaceId}>
                 <Space
-                  userName={space.userName}
+                  userName={space.ownerNickName}
                   spaceId={space.spaceId}
                   type="Card"
                   spaceName={space.spaceName}

--- a/src/components/common/Sidebar/Sidebar.tsx
+++ b/src/components/common/Sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { useRef } from 'react'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
+import { cls } from '@/utils'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { ArchiveBoxIcon, StarIcon } from '@heroicons/react/24/solid'
 import Link from 'next/link'
@@ -127,8 +128,10 @@ const Sidebar = ({ onClose }: SidebarProps) => {
             </div>
           )}
         </div>
-        <div className="flex flex-col gap-y-2">
-          <ThemeButton />
+        <div className="flex flex-col">
+          <div className="pb-2">
+            <ThemeButton />
+          </div>
           {currentUser && (
             <button
               className="border-t border-slate3 px-2 py-3 text-left text-sm text-gray9"

--- a/src/components/common/Sidebar/Sidebar.tsx
+++ b/src/components/common/Sidebar/Sidebar.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
-import { mock_userData } from '@/data'
+import { useRef } from 'react'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import { ArchiveBoxIcon, StarIcon } from '@heroicons/react/24/solid'
@@ -25,7 +24,6 @@ const Sidebar = ({ onClose }: SidebarProps) => {
     keyWord: '',
   })
 
-  const user = mock_userData
   const sidebarRef = useRef<HTMLDivElement>(null)
   const { spaceType, handleSpaceType, handleOverlayClick, logout } = useSidebar(
     {
@@ -131,7 +129,7 @@ const Sidebar = ({ onClose }: SidebarProps) => {
         </div>
         <div className="flex flex-col gap-y-2">
           <ThemeButton />
-          {user && (
+          {currentUser && (
             <button
               className="border-t border-slate3 px-2 py-3 text-left text-sm text-gray9"
               onClick={logout}>

--- a/src/components/common/Tab/TabItem.tsx
+++ b/src/components/common/Tab/TabItem.tsx
@@ -15,7 +15,7 @@ const TabItem = ({ active, text, dest }: TabItemProps) => {
       <div
         className={cls(
           active ? 'border-emerald5' : 'border-slate3',
-          `flex w-[100%] cursor-pointer items-center justify-center border-b py-4 text-sm font-bold text-gray9 transition ease-in-out`,
+          `flex w-[100%] cursor-pointer items-center justify-center border-b py-4 text-sm font-bold text-gray9`,
         )}>
         {text}
       </div>

--- a/src/components/common/ThemeButton/ThemeButton.tsx
+++ b/src/components/common/ThemeButton/ThemeButton.tsx
@@ -1,15 +1,41 @@
 'use client'
 
+import { useRef } from 'react'
+import { cls } from '@/utils'
+import { MoonIcon, SunIcon } from '@heroicons/react/24/solid'
 import { useTheme } from 'next-themes'
 
 const ThemeButton = () => {
-  const { theme, setTheme } = useTheme()
+  const { systemTheme, theme, setTheme } = useTheme()
+  const currentTheme = theme === 'system' ? systemTheme : theme
+  const isMounted = useRef(false)
+
+  const handleClick = () => {
+    if (!isMounted.current) {
+      isMounted.current = true
+    }
+    setTheme(currentTheme === 'dark' ? 'light' : 'dark')
+  }
 
   return (
     <button
-      className="rounded-md border p-2 text-xs"
-      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
-      테마 버튼
+      className="rounded-full border border-slate3 p-2 text-xs"
+      onClick={handleClick}>
+      {theme === 'dark' ? (
+        <MoonIcon
+          className={cls(
+            'h-5 w-5',
+            isMounted.current && 'animate-darkModeSpin',
+          )}
+        />
+      ) : (
+        <SunIcon
+          className={cls(
+            'h-5 w-5',
+            isMounted.current && 'animate-darkModeSpin',
+          )}
+        />
+      )}
     </button>
   )
 }

--- a/src/hooks/useGetPopularLinks.ts
+++ b/src/hooks/useGetPopularLinks.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react'
+import { fetchGetPopularLinks } from '@/services/link/link'
+import { PopularLinkResBody } from '@/types'
+
+const useGetPopularLinks = () => {
+  const [links, setLinks] = useState<PopularLinkResBody[]>()
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await fetchGetPopularLinks()
+      const linkData = data.responses
+      setLinks(linkData)
+    }
+    fetchData()
+  }, [])
+
+  return links
+}
+
+export default useGetPopularLinks

--- a/src/services/link/link.ts
+++ b/src/services/link/link.ts
@@ -83,7 +83,6 @@ const fetchLikeLink = async ({ linkId }: FetchLikeLinkProps) => {
   }
 }
 
-
 const fetchUnLikeLink = async ({ linkId }: FetchLikeLinkProps) => {
   const path = `/api/links/${linkId}/like`
 
@@ -116,6 +115,17 @@ const fetchReadSaveLink = async ({
   }
 }
 
+const fetchGetPopularLinks = async () => {
+  const path = `/api/links`
+
+  try {
+    const response = await apiClient.get(path)
+    return response
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
+}
+
 export {
   fetchGetLinks,
   fetchCreateLink,
@@ -123,4 +133,5 @@ export {
   fetchLikeLink,
   fetchUnLikeLink,
   fetchReadSaveLink,
+  fetchGetPopularLinks,
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -214,3 +214,13 @@ export interface CommentResBody {
 export interface CreateCommentReqBody {
   content: string
 }
+
+export interface PopularLinkResBody {
+  linkId: number
+  title: string
+  url: string
+  tagName: string
+  tagColor: string
+  likeCount: number
+  isLiked: boolean
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -161,7 +161,7 @@ export interface SpaceResBody {
   spaceId: number
   spaceName: string
   description: string
-  userName: string
+  ownerNickName: string
   category: string
   viewCount: number
   scrapCount: number

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,6 +50,9 @@ const config: Config = {
       fontFamily: {
         sans: ['"Pretendard"', ...fontFamily.sans],
       },
+      animation: {
+        darkModeSpin: 'spin 1s ease 0s',
+      },
     },
   },
   plugins: [require('tailwind-scrollbar-hide')],


### PR DESCRIPTION
## 📑 이슈 번호
- close #162 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 인기 링크 조회 api 연결했습니다.
<img width="300" alt="LinkHub-FE_api-popular-link" src="https://github.com/Team-TenTen/LinkHub-FE/assets/49032882/58679f08-516e-4fd7-a4dc-b826c333e322">


## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
- 메인 페이지 스페이스 모음에서 팔로우 카테고리를 제거했습니다.
- 스페이스 컴포넌트 카드 타입에 유저 이름을 적용했습니다.

### Sidebar 컴포넌트

https://github.com/Team-TenTen/LinkHub-FE/assets/49032882/4e32c1f1-7946-4d3c-bd6b-f60ac56ee148

- 테마 버튼 애니메이션 추가 및 시스템 테마 적용했습니다.

<img width="300" alt="LinkHub-FE_api-popular-link_3" src="https://github.com/Team-TenTen/LinkHub-FE/assets/49032882/68810ab1-2a48-45c6-ae3d-7aa1bded75fc">

- 로그인 유무에 따라 로그아웃 버튼 표시되도록 수정했습니다.
