### PR TITLE
링크 수정 api 연결

### DIFF
--- a/src/app/(routes)/space/[spaceId]/page.tsx
+++ b/src/app/(routes)/space/[spaceId]/page.tsx
@@ -122,6 +122,7 @@ const SpacePage = () => {
             fetchFn={fetchGetLinks}
             sort={sort ?? 'created_at'}
             tagId={Number(tag) || undefined}
+            isCanEdit={space.isCanEdit}
           />
         )}
         <SpaceMemberList members={space?.memberDetailInfos} />

--- a/src/app/(routes)/space/[spaceId]/page.tsx
+++ b/src/app/(routes)/space/[spaceId]/page.tsx
@@ -30,7 +30,7 @@ const SpacePage = () => {
   const [view, handleChangeList, handleChangeCard] = useViewLink()
   const { currentTab, tabList } = useTab({ type: 'space', space })
   const { sort, sortIndex, handleSortChange } = useSortParam('link')
-  const { tags } = useGetTags({ spaceId: space?.spaceId })
+  const { tags, refetchTags } = useGetTags({ spaceId: space?.spaceId })
   const { tag, tagIndex, handleTagChange } = useTagParam({ tags })
 
   return (
@@ -130,6 +130,7 @@ const SpacePage = () => {
                 (member) => member.memberId === currentUser?.memberId,
               )
             }
+            refetchTags={refetchTags}
           />
         )}
         <SpaceMemberList members={space?.memberDetailInfos} />

--- a/src/app/(routes)/space/[spaceId]/page.tsx
+++ b/src/app/(routes)/space/[spaceId]/page.tsx
@@ -12,6 +12,7 @@ import useTab from '@/components/common/Tab/hooks/useTab'
 import useToggle from '@/components/common/Toggle/hooks/useToggle'
 import { CATEGORIES_RENDER, MIN_TAB_NUMBER } from '@/constants'
 import { useSortParam } from '@/hooks'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import useTagParam from '@/hooks/useTagParam'
 import { fetchGetLinks } from '@/services/link/link'
 import { cls } from '@/utils'
@@ -23,6 +24,7 @@ import {
 } from '@heroicons/react/24/solid'
 
 const SpacePage = () => {
+  const { currentUser } = useCurrentUser()
   const [space] = useGetSpace()
   const [isEdit, editToggle] = useToggle(false)
   const [view, handleChangeList, handleChangeCard] = useViewLink()
@@ -123,6 +125,11 @@ const SpacePage = () => {
             sort={sort ?? 'created_at'}
             tagId={Number(tag) || undefined}
             isCanEdit={space.isCanEdit}
+            isMember={
+              !!space?.memberDetailInfos.find(
+                (member) => member.memberId === currentUser?.memberId,
+              )
+            }
           />
         )}
         <SpaceMemberList members={space?.memberDetailInfos} />

--- a/src/app/api/space/[spaceId]/links/route.ts
+++ b/src/app/api/space/[spaceId]/links/route.ts
@@ -46,6 +46,27 @@ export async function POST(req: NextRequest) {
   }
 }
 
+export async function PUT(req: NextRequest) {
+  const { token } = useServerCookie()
+  const { spaceId, linkId, url, title, tagName, color } = await req.json()
+  const path = `/spaces/${spaceId}/links/${linkId}`
+  const body = { url, title, tagName, color }
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  }
+
+  try {
+    const response = await apiServer.put(path, body, {}, headers)
+    const data = await response.json()
+    return NextResponse.json(data)
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.message },
+      { status: error.response.status },
+    )
+  }
+}
+
 export async function DELETE(req: NextRequest) {
   const { token } = useServerCookie()
   const { searchParams } = new URL(req.url)

--- a/src/app/api/space/[spaceId]/links/route.ts
+++ b/src/app/api/space/[spaceId]/links/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
   const { token } = useServerCookie()
   const { spaceId, url, title, tagName, color } = await req.json()
   const path = `/spaces/${spaceId}/links`
-  const body = { url, title, ...(tagName && { tagName: tagName }), color }
+  const body = { url, title, tagName, color }
   const headers = {
     Authorization: `Bearer ${token}`,
   }

--- a/src/app/api/space/[spaceId]/links/route.ts
+++ b/src/app/api/space/[spaceId]/links/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
   const { token } = useServerCookie()
   const { spaceId, url, title, tagName, color } = await req.json()
   const path = `/spaces/${spaceId}/links`
-  const body = { url, title, tagName, color }
+  const body = { url, title, ...(tagName && { tagName: tagName }), color }
   const headers = {
     Authorization: `Bearer ${token}`,
   }

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -43,7 +43,7 @@ const Input = forwardRef(
             ref={ref}
             type={type}
             className={cls(
-              'rounded-md border bg-bgColor px-3 py-2.5 text-sm font-medium text-gray9 placeholder-gray4 outline-none disabled:border-gray3 disabled:placeholder-gray3',
+              'rounded-md border bg-bgColor px-3 py-2.5 text-sm font-medium text-gray9 placeholder-gray4 outline-none disabled:border-gray3 disabled:text-gray3 disabled:placeholder-gray3',
               inputButton && buttonColor === 'green'
                 ? 'border-emerald6 pr-20'
                 : 'border-slate5',

--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -276,7 +276,7 @@ const LinkItem = ({
                         url,
                         title,
                         tagName,
-                        color: 'emerald',
+                        color: tagColor,
                       })
                       modalClose()
                     }

--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -20,6 +20,7 @@ import Input from '../Input/Input'
 import { CreateLinkFormValue, linkViewHistories } from '../LinkList/LinkList'
 import useGetMeta from '../LinkList/hooks/useGetMeta'
 import LoginModal from '../Modal/LoginModal'
+import { RefetchTagsType } from '../Space/hooks/useGetTags'
 import { DELETE_TEXT } from './\bconstants'
 import useDeleteLink from './hooks/useDeleteLink'
 import useLikeLink from './hooks/useLikeLink'
@@ -41,6 +42,7 @@ export interface LinkItemProps {
   edit?: boolean
   isMember?: boolean
   type?: 'list' | 'card'
+  refetchTags?: RefetchTagsType
 }
 
 const LinkItem = ({
@@ -58,6 +60,7 @@ const LinkItem = ({
   edit = false,
   isMember,
   type = 'list',
+  refetchTags,
 }: LinkItemProps) => {
   const { isLoggedIn } = useCurrentUser()
   const { Modal, isOpen, modalClose, currentModal, handleOpenCurrentModal } =
@@ -86,8 +89,8 @@ const LinkItem = ({
     handleChangeUrl,
     handleGetMeta,
   } = useGetMeta({ setValue, modalClose })
-  const { handleUpdateLink } = useUpdateLink({ spaceId, linkId })
-  const { handleDeleteLink } = useDeleteLink()
+  const { handleUpdateLink } = useUpdateLink({ spaceId, linkId, refetchTags })
+  const { handleDeleteLink } = useDeleteLink({ refetchTags })
   const { handleSaveReadInfo } = useReadSaveLink()
   const { isLiked, likeCount, handleClickLike } = useLikeLink({
     linkId,

--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -306,6 +306,7 @@ const LinkItem = ({
                 label={LINK_FORM.URL}
                 placeholder={LINK_FORM_PLACEHOLDER.URL}
                 inputButton={true}
+                buttonText="확인"
                 onButtonClick={() => handleGetMeta({ url: getValues('url') })}
                 validation={
                   isUrlCheck && isShowFormError

--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -306,7 +306,7 @@ const LinkItem = ({
                 label={LINK_FORM.URL}
                 placeholder={LINK_FORM_PLACEHOLDER.URL}
                 inputButton={true}
-                buttonText="확인"
+                buttonText={LINK_FORM.URL_INPUT_BUTTON}
                 onButtonClick={() => handleGetMeta({ url: getValues('url') })}
                 validation={
                   isUrlCheck && isShowFormError

--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -18,6 +18,11 @@ import Button from '../Button/Button'
 import Chip, { ChipColors } from '../Chip/Chip'
 import Input from '../Input/Input'
 import { CreateLinkFormValue, linkViewHistories } from '../LinkList/LinkList'
+import {
+  LINK_FORM,
+  LINK_FORM_PLACEHOLDER,
+  LINK_FORM_VALIDATION,
+} from '../LinkList/constants'
 import useGetMeta from '../LinkList/hooks/useGetMeta'
 import LoginModal from '../Modal/LoginModal'
 import { RefetchTagsType } from '../Space/hooks/useGetTags'
@@ -270,7 +275,7 @@ const LinkItem = ({
               ? (() => {
                   setIsShowFormError(true)
                   if (!isUrlCheck) {
-                    setUrlErrorText('URL 입력 후 추가 버튼을 눌러주세요.')
+                    setUrlErrorText(LINK_FORM_VALIDATION.URL_NOT_BUTTTON)
                     return
                   }
                   handleSubmit(async ({ url, title, tagName }) => {
@@ -294,11 +299,12 @@ const LinkItem = ({
                 {...register('url', {
                   required: {
                     value: true,
-                    message: 'URL 입력 후 추가 버튼을 눌러주세요.',
+                    message: LINK_FORM_VALIDATION.URL_NOT_BUTTTON,
                   },
                   onChange: handleChangeUrl,
                 })}
-                label="URl"
+                label={LINK_FORM.URL}
+                placeholder={LINK_FORM_PLACEHOLDER.URL}
                 inputButton={true}
                 onButtonClick={() => handleGetMeta({ url: getValues('url') })}
                 validation={
@@ -311,19 +317,19 @@ const LinkItem = ({
                 {...register('title', {
                   minLength: {
                     value: 2,
-                    message: '제목은 2글자 이상 50글자 이하로 작성해야 합니다.',
+                    message: LINK_FORM_VALIDATION.TITLE_LENGTH,
                   },
                   maxLength: {
                     value: 50,
-                    message: '제목은 2글자 이상 50글자 이하로 작성해야 합니다.',
+                    message: LINK_FORM_VALIDATION.TITLE_LENGTH,
                   },
                   required: {
                     value: true,
-                    message: '제목을 입력해 주세요.',
+                    message: LINK_FORM_VALIDATION.NONE_TITLE,
                   },
                 })}
-                label="제목"
-                placeholder="제목을 입력해 주세요. (2 ~ 50글자)"
+                label={LINK_FORM.TITLE}
+                placeholder={LINK_FORM_PLACEHOLDER.TITLE}
                 disabled={!isUrlCheck}
                 validation={
                   isUrlCheck && isShowFormError ? errors.title?.message : ''
@@ -333,11 +339,11 @@ const LinkItem = ({
                 {...register('tagName', {
                   maxLength: {
                     value: 10,
-                    message: '태그는 10글자 이하로 작성해야 합니다.',
+                    message: LINK_FORM_VALIDATION.TAG_LENGTH,
                   },
                 })}
-                label="태그"
-                placeholder="태그를 입력해 주세요. (0 ~ 10글자)"
+                label={LINK_FORM.TAG}
+                placeholder={LINK_FORM_PLACEHOLDER.TAG}
                 validation={isShowFormError ? errors.tagName?.message : ''}
               />
             </div>

--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useModal } from '@/hooks'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
@@ -40,6 +39,7 @@ export interface LinkItemProps {
   read?: boolean
   summary?: boolean
   edit?: boolean
+  isMember?: boolean
   type?: 'list' | 'card'
 }
 
@@ -56,6 +56,7 @@ const LinkItem = ({
   read = false,
   summary = false,
   edit = false,
+  isMember,
   type = 'list',
 }: LinkItemProps) => {
   const { isLoggedIn } = useCurrentUser()
@@ -74,7 +75,6 @@ const LinkItem = ({
       tagName,
     },
   })
-
   const {
     isUrlCheck,
     setIsUrlCheck,
@@ -100,7 +100,7 @@ const LinkItem = ({
       {type === 'list' ? (
         <div className="flex items-center justify-between gap-2 border-t border-slate3 px-3 py-2 last:border-b">
           <Link
-            onClick={() => handleSaveReadInfo({ spaceId, linkId })}
+            onClick={() => isMember && handleSaveReadInfo({ spaceId, linkId })}
             className="cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap text-sm font-medium text-gray9"
             href={url}
             target="_blank">

--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -128,7 +128,7 @@ const LinkItem = ({
                 {readUsers?.map((readUser) => (
                   <Avatar
                     key={readUser.memberName}
-                    src="/duck.jpg"
+                    src={readUser.memberProfileImage || '/duck.jpg'}
                     width={20}
                     height={20}
                     alt="아바타"

--- a/src/components/common/LinkItem/hooks/useDeleteLink.ts
+++ b/src/components/common/LinkItem/hooks/useDeleteLink.ts
@@ -1,7 +1,12 @@
 import { FetchDeleteLinkProps, fetchDeleteLink } from '@/services/link/link'
 import { useQueryClient } from '@tanstack/react-query'
+import { RefetchTagsType } from '../../Space/hooks/useGetTags'
 
-const useDeleteLink = () => {
+export interface UseDeleteLinkProps {
+  refetchTags?: RefetchTagsType
+}
+
+const useDeleteLink = ({ refetchTags }: UseDeleteLinkProps) => {
   const queryClient = useQueryClient()
 
   const handleDeleteLink = async ({
@@ -10,6 +15,7 @@ const useDeleteLink = () => {
   }: FetchDeleteLinkProps) => {
     await fetchDeleteLink({ spaceId, linkId })
     await queryClient.invalidateQueries({ queryKey: ['links', spaceId] })
+    refetchTags?.()
   }
 
   return { handleDeleteLink }

--- a/src/components/common/LinkItem/hooks/useReadSaveLink.ts
+++ b/src/components/common/LinkItem/hooks/useReadSaveLink.ts
@@ -12,6 +12,7 @@ const useReadSaveLink = () => {
   const handleSaveReadInfo = ({ spaceId, linkId }: HandleSaveReadInfoProps) => {
     if (spaceId && linkId && isLoggedIn) {
       fetchReadSaveLink({ spaceId, linkId })
+      console.log('접속 저장됨')
     }
   }
 

--- a/src/components/common/LinkItem/hooks/useUpdateLink.ts
+++ b/src/components/common/LinkItem/hooks/useUpdateLink.ts
@@ -1,5 +1,6 @@
 import { fetchUpdateLink } from '@/services/link/link'
 import { useQueryClient } from '@tanstack/react-query'
+import { RefetchTagsType } from '../../Space/hooks/useGetTags'
 
 interface HandleUpdateLinkProps {
   url: string
@@ -11,9 +12,14 @@ interface HandleUpdateLinkProps {
 interface UseUpdateLinkProps {
   spaceId?: number
   linkId: number
+  refetchTags?: RefetchTagsType
 }
 
-const useUpdateLink = ({ spaceId, linkId }: UseUpdateLinkProps) => {
+const useUpdateLink = ({
+  spaceId,
+  linkId,
+  refetchTags,
+}: UseUpdateLinkProps) => {
   const queryClient = useQueryClient()
   const handleUpdateLink = async ({
     url,
@@ -30,6 +36,7 @@ const useUpdateLink = ({ spaceId, linkId }: UseUpdateLinkProps) => {
       color,
     })
     await queryClient.invalidateQueries({ queryKey: ['links', spaceId] })
+    refetchTags?.()
   }
 
   return { handleUpdateLink }

--- a/src/components/common/LinkItem/hooks/useUpdateLink.ts
+++ b/src/components/common/LinkItem/hooks/useUpdateLink.ts
@@ -1,0 +1,38 @@
+import { fetchUpdateLink } from '@/services/link/link'
+import { useQueryClient } from '@tanstack/react-query'
+
+interface HandleUpdateLinkProps {
+  url: string
+  title: string
+  tagName: string
+  color: string
+}
+
+interface UseUpdateLinkProps {
+  spaceId?: number
+  linkId: number
+}
+
+const useUpdateLink = ({ spaceId, linkId }: UseUpdateLinkProps) => {
+  const queryClient = useQueryClient()
+  const handleUpdateLink = async ({
+    url,
+    title,
+    tagName,
+    color = 'emerald',
+  }: HandleUpdateLinkProps) => {
+    await fetchUpdateLink({
+      spaceId,
+      linkId,
+      url,
+      title,
+      tagName,
+      color,
+    })
+    await queryClient.invalidateQueries({ queryKey: ['links', spaceId] })
+  }
+
+  return { handleUpdateLink }
+}
+
+export default useUpdateLink

--- a/src/components/common/LinkList/LinkList.tsx
+++ b/src/components/common/LinkList/LinkList.tsx
@@ -197,7 +197,7 @@ const LinkList = ({
               label={LINK_FORM.URL}
               placeholder={LINK_FORM_PLACEHOLDER.URL}
               inputButton={true}
-              buttonText="확인"
+              buttonText={LINK_FORM.URL_INPUT_BUTTON}
               onButtonClick={() => handleGetMeta({ url: getValues('url') })}
               validation={isUrlCheck ? errors.url?.message : urlErrorText}
             />

--- a/src/components/common/LinkList/LinkList.tsx
+++ b/src/components/common/LinkList/LinkList.tsx
@@ -197,6 +197,7 @@ const LinkList = ({
               label={LINK_FORM.URL}
               placeholder={LINK_FORM_PLACEHOLDER.URL}
               inputButton={true}
+              buttonText="확인"
               onButtonClick={() => handleGetMeta({ url: getValues('url') })}
               validation={isUrlCheck ? errors.url?.message : urlErrorText}
             />

--- a/src/components/common/LinkList/LinkList.tsx
+++ b/src/components/common/LinkList/LinkList.tsx
@@ -41,6 +41,7 @@ export interface LinkListProps {
   sort: string
   tagId?: number
   isCanEdit: boolean
+  isMember: boolean
 }
 
 export interface CreateLinkFormValue {
@@ -59,6 +60,7 @@ const LinkList = ({
   sort,
   tagId,
   isCanEdit,
+  isMember,
 }: LinkListProps) => {
   const { Modal, isOpen, modalOpen, modalClose } = useModal()
   const { handleCreateLink } = useCreateLink({ spaceId })
@@ -131,6 +133,7 @@ const LinkList = ({
                 read={read}
                 summary={summary}
                 edit={edit}
+                isMember={isMember}
                 type={type}
                 key={link.linkId}
               />

--- a/src/components/common/LinkList/LinkList.tsx
+++ b/src/components/common/LinkList/LinkList.tsx
@@ -80,8 +80,8 @@ const LinkList = ({
     isUrlCheck,
     urlErrorText,
     setUrlErrorText,
-    isShowTitleError,
-    setIsShowTitleError,
+    isShowFormError,
+    setIsShowFormError,
     handleModalClose,
     handleChangeUrl,
     handleGetMeta,
@@ -154,7 +154,7 @@ const LinkList = ({
           confirmText="추가"
           onClose={handleModalClose}
           onConfirm={() => {
-            setIsShowTitleError(true)
+            setIsShowFormError(true)
             if (!isUrlCheck) {
               setUrlErrorText('URL 입력 후 추가 버튼을 눌러주세요.')
               return
@@ -204,7 +204,7 @@ const LinkList = ({
               label="제목"
               placeholder="제목을 입력해 주세요. (2 ~ 50글자)"
               disabled={!isUrlCheck}
-              validation={isShowTitleError ? errors.title?.message : ''}
+              validation={isShowFormError ? errors.title?.message : ''}
             />
             <Input
               {...register('tagName', {

--- a/src/components/common/LinkList/LinkList.tsx
+++ b/src/components/common/LinkList/LinkList.tsx
@@ -8,6 +8,7 @@ import Button from '../Button/Button'
 import { ChipColors } from '../Chip/Chip'
 import Input from '../Input/Input'
 import LinkItem from '../LinkItem/LinkItem'
+import { RefetchTagsType } from '../Space/hooks/useGetTags'
 import { ADD_LINK_TEXT, MORE_TEXT } from './constants'
 import useCreateLink from './hooks/useCreateLink'
 import useGetMeta from './hooks/useGetMeta'
@@ -42,6 +43,7 @@ export interface LinkListProps {
   tagId?: number
   isCanEdit: boolean
   isMember: boolean
+  refetchTags?: RefetchTagsType
 }
 
 export interface CreateLinkFormValue {
@@ -61,9 +63,10 @@ const LinkList = ({
   tagId,
   isCanEdit,
   isMember,
+  refetchTags,
 }: LinkListProps) => {
   const { Modal, isOpen, modalOpen, modalClose } = useModal()
-  const { handleCreateLink } = useCreateLink({ spaceId })
+  const { handleCreateLink } = useCreateLink({ spaceId, refetchTags })
   const {
     register,
     getValues,
@@ -135,6 +138,7 @@ const LinkList = ({
                 edit={edit}
                 isMember={isMember}
                 type={type}
+                refetchTags={refetchTags}
                 key={link.linkId}
               />
             )),

--- a/src/components/common/LinkList/LinkList.tsx
+++ b/src/components/common/LinkList/LinkList.tsx
@@ -9,7 +9,13 @@ import { ChipColors } from '../Chip/Chip'
 import Input from '../Input/Input'
 import LinkItem from '../LinkItem/LinkItem'
 import { RefetchTagsType } from '../Space/hooks/useGetTags'
-import { ADD_LINK_TEXT, MORE_TEXT } from './constants'
+import {
+  ADD_LINK_TEXT,
+  LINK_FORM,
+  LINK_FORM_PLACEHOLDER,
+  LINK_FORM_VALIDATION,
+  MORE_TEXT,
+} from './constants'
 import useCreateLink from './hooks/useCreateLink'
 import useGetMeta from './hooks/useGetMeta'
 import useLinksQuery from './hooks/useLinksQuery'
@@ -163,7 +169,7 @@ const LinkList = ({
           onConfirm={() => {
             setIsShowFormError(true)
             if (!isUrlCheck) {
-              setUrlErrorText('URL 입력 후 추가 버튼을 눌러주세요.')
+              setUrlErrorText(LINK_FORM_VALIDATION.URL_NOT_BUTTTON)
               return
             }
             handleSubmit(async ({ url, title, tagName }) => {
@@ -184,11 +190,12 @@ const LinkList = ({
               {...register('url', {
                 required: {
                   value: true,
-                  message: 'URL 입력 후 추가 버튼을 눌러주세요.',
+                  message: LINK_FORM_VALIDATION.URL_NOT_BUTTTON,
                 },
                 onChange: handleChangeUrl,
               })}
-              label="URl"
+              label={LINK_FORM.URL}
+              placeholder={LINK_FORM_PLACEHOLDER.URL}
               inputButton={true}
               onButtonClick={() => handleGetMeta({ url: getValues('url') })}
               validation={isUrlCheck ? errors.url?.message : urlErrorText}
@@ -197,19 +204,19 @@ const LinkList = ({
               {...register('title', {
                 minLength: {
                   value: 2,
-                  message: '제목은 2글자 이상 50글자 이하로 작성해야 합니다.',
+                  message: LINK_FORM_VALIDATION.TITLE_LENGTH,
                 },
                 maxLength: {
                   value: 50,
-                  message: '제목은 2글자 이상 50글자 이하로 작성해야 합니다.',
+                  message: LINK_FORM_VALIDATION.TITLE_LENGTH,
                 },
                 required: {
                   value: true,
-                  message: '제목을 입력해 주세요.',
+                  message: LINK_FORM_VALIDATION.NONE_TITLE,
                 },
               })}
-              label="제목"
-              placeholder="제목을 입력해 주세요. (2 ~ 50글자)"
+              label={LINK_FORM.TITLE}
+              placeholder={LINK_FORM_PLACEHOLDER.TITLE}
               disabled={!isUrlCheck}
               validation={isShowFormError ? errors.title?.message : ''}
             />
@@ -217,11 +224,11 @@ const LinkList = ({
               {...register('tagName', {
                 maxLength: {
                   value: 10,
-                  message: '태그는 10글자 이하로 작성해야 합니다.',
+                  message: LINK_FORM_VALIDATION.TAG_LENGTH,
                 },
               })}
-              label="태그"
-              placeholder="태그를 입력해 주세요. (0 ~ 10글자)"
+              label={LINK_FORM.TAG}
+              placeholder={LINK_FORM_PLACEHOLDER.TAG}
               validation={errors.tagName?.message || ''}
             />
           </div>

--- a/src/components/common/LinkList/LinkList.tsx
+++ b/src/components/common/LinkList/LinkList.tsx
@@ -14,6 +14,7 @@ import {
   URL_INPUT_VALIDATION_TEXT,
 } from './constants'
 import useCreateLink from './hooks/useCreateLink'
+import useGetMeta from './hooks/useGetMeta'
 import useLinksQuery from './hooks/useLinksQuery'
 
 export interface linkViewHistories {
@@ -72,13 +73,9 @@ const LinkList = ({
         tagName: '',
       },
     })
-  const {
-    isUrlCheck,
-    setIsUrlCheck,
-    isUrlError,
-    handleGetMeta,
-    handleCreateLink,
-  } = useCreateLink(setValue)
+  const { isUrlCheck, setIsUrlCheck, isUrlError, handleGetMeta } =
+    useGetMeta(setValue)
+  const { handleCreateLink } = useCreateLink()
   const { links, fetchNextPage, hasNextPage } = useLinksQuery({
     spaceId,
     fetchFn,

--- a/src/components/common/LinkList/LinkList.tsx
+++ b/src/components/common/LinkList/LinkList.tsx
@@ -43,6 +43,7 @@ export interface LinkListProps {
   fetchFn: ({ pageNumber, pageSize }: GetLinksReqBody) => Promise<any>
   sort: string
   tagId?: number
+  isCanEdit: boolean
 }
 
 export interface CreateLinkFormValue {
@@ -60,6 +61,7 @@ const LinkList = ({
   fetchFn,
   sort,
   tagId,
+  isCanEdit,
 }: LinkListProps) => {
   const { Modal, isOpen, modalOpen, modalClose } = useModal()
   const { register, getValues, setValue, handleSubmit, reset } =
@@ -91,16 +93,18 @@ const LinkList = ({
           type === 'list' ? 'flex flex-col' : 'grid grid-cols-2 gap-2',
           !hasNextPage && 'mb-0.5 pb-10',
         )}>
-        <button
-          className={cls(
-            'flex bg-slate-100 px-3 py-2.5 text-sm font-medium text-gray9 dark:bg-slate-800',
-            type === 'list'
-              ? 'border-t border-slate3'
-              : 'min-h-[101.5px] items-center justify-center rounded-md border',
-          )}
-          onClick={modalOpen}>
-          <div className="text-gray9">{ADD_LINK_TEXT}</div>
-        </button>
+        {isCanEdit && (
+          <button
+            className={cls(
+              'flex bg-slate-100 px-3 py-2.5 text-sm font-medium text-gray9 dark:bg-slate-800',
+              type === 'list'
+                ? 'border-t border-slate3'
+                : 'min-h-[101.5px] items-center justify-center rounded-md border',
+            )}
+            onClick={modalOpen}>
+            <div className="text-gray9">{ADD_LINK_TEXT}</div>
+          </button>
+        )}
         <>
           {links?.pages.map((group) =>
             group.responses.map((link: Link) => (

--- a/src/components/common/LinkList/LinkList.tsx
+++ b/src/components/common/LinkList/LinkList.tsx
@@ -3,7 +3,7 @@
 import { useForm } from 'react-hook-form'
 import { useModal } from '@/hooks'
 import { GetLinksReqBody } from '@/types'
-import { cls } from '@/utils'
+import { cls, getRandomColor } from '@/utils'
 import Button from '../Button/Button'
 import { ChipColors } from '../Chip/Chip'
 import Input from '../Input/Input'
@@ -168,7 +168,7 @@ const LinkList = ({
                   url,
                   title,
                   tagName,
-                  color: 'emerald',
+                  color: getRandomColor(),
                 })
                 modalClose()
               }

--- a/src/components/common/LinkList/constants/index.ts
+++ b/src/components/common/LinkList/constants/index.ts
@@ -20,5 +20,4 @@ export const LINK_FORM_VALIDATION = {
   NONE_TITLE: '제목을 입력해 주세요.',
   TITLE_LENGTH: '제목은 2글자 이상 50글자 이하로 작성해야 합니다.',
   TAG_LENGTH: '태그는 10글자 이하로 작성해야 합니다.',
-  NONE_TAG: '태그를 입력해 주세요. (0 ~ 10글자)',
 }

--- a/src/components/common/LinkList/constants/index.ts
+++ b/src/components/common/LinkList/constants/index.ts
@@ -1,6 +1,5 @@
 export const ADD_LINK_TEXT = '+ 링크 추가하기'
 export const MORE_TEXT = '더 보기'
-export const URL_INPUT_VALIDATION_TEXT = '올바르지 않은 URL입니다.'
 
 export const LINK_FORM = {
   URL: 'URL',
@@ -16,7 +15,7 @@ export const LINK_FORM_PLACEHOLDER = {
 
 export const LINK_FORM_VALIDATION = {
   INCORRECT_URL: '올바르지 않은 URL입니다.',
-  URL_NOT_BUTTTON: 'URL 입력 후 추가 버튼을 눌러주세요.',
+  URL_NOT_BUTTTON: 'URL 입력 후 확인 버튼을 눌러주세요.',
   NONE_TITLE: '제목을 입력해 주세요.',
   TITLE_LENGTH: '제목은 2글자 이상 50글자 이하로 작성해야 합니다.',
   TAG_LENGTH: '태그는 10글자 이하로 작성해야 합니다.',

--- a/src/components/common/LinkList/constants/index.ts
+++ b/src/components/common/LinkList/constants/index.ts
@@ -5,6 +5,7 @@ export const LINK_FORM = {
   URL: 'URL',
   TITLE: '제목',
   TAG: '태그',
+  URL_INPUT_BUTTON: '확인',
 }
 
 export const LINK_FORM_PLACEHOLDER = {

--- a/src/components/common/LinkList/constants/index.ts
+++ b/src/components/common/LinkList/constants/index.ts
@@ -1,3 +1,24 @@
 export const ADD_LINK_TEXT = '+ 링크 추가하기'
 export const MORE_TEXT = '더 보기'
 export const URL_INPUT_VALIDATION_TEXT = '올바르지 않은 URL입니다.'
+
+export const LINK_FORM = {
+  URL: 'URL',
+  TITLE: '제목',
+  TAG: '태그',
+}
+
+export const LINK_FORM_PLACEHOLDER = {
+  URL: 'URL을 입력해 주세요.',
+  TITLE: '제목을 입력해 주세요. (2 ~ 50글자)',
+  TAG: '태그를 입력해 주세요. (0 ~ 10글자)',
+}
+
+export const LINK_FORM_VALIDATION = {
+  INCORRECT_URL: '올바르지 않은 URL입니다.',
+  URL_NOT_BUTTTON: 'URL 입력 후 추가 버튼을 눌러주세요.',
+  NONE_TITLE: '제목을 입력해 주세요.',
+  TITLE_LENGTH: '제목은 2글자 이상 50글자 이하로 작성해야 합니다.',
+  TAG_LENGTH: '태그는 10글자 이하로 작성해야 합니다.',
+  NONE_TAG: '태그를 입력해 주세요. (0 ~ 10글자)',
+}

--- a/src/components/common/LinkList/hooks/useCreateLink.ts
+++ b/src/components/common/LinkList/hooks/useCreateLink.ts
@@ -1,10 +1,13 @@
 'use client'
 
 import { FetchCreateLinkProps, fetchCreateLink } from '@/services/link/link'
+import { fetchGetTags } from '@/services/space/space'
 import { useQueryClient } from '@tanstack/react-query'
+import { RefetchTagsType } from '../../Space/hooks/useGetTags'
 
 export interface UseCreateLinkProps {
   spaceId?: number
+  refetchTags?: RefetchTagsType
 }
 export interface UseCreateLinkReturnType {
   handleCreateLink: ({
@@ -17,6 +20,7 @@ export interface UseCreateLinkReturnType {
 
 const useCreateLink = ({
   spaceId,
+  refetchTags,
 }: UseCreateLinkProps): UseCreateLinkReturnType => {
   const queryclient = useQueryClient()
 
@@ -33,7 +37,12 @@ const useCreateLink = ({
       tagName,
       color,
     })
+
+    await fetchGetTags({
+      spaceId,
+    })
     await queryclient.invalidateQueries({ queryKey: ['links', spaceId] })
+    refetchTags?.()
   }
 
   return {

--- a/src/components/common/LinkList/hooks/useCreateLink.ts
+++ b/src/components/common/LinkList/hooks/useCreateLink.ts
@@ -1,17 +1,11 @@
 'use client'
 
-import { Dispatch, SetStateAction, useState } from 'react'
 import { UseFormSetValue } from 'react-hook-form'
 import { FetchCreateLinkProps, fetchCreateLink } from '@/services/link/link'
-import { FetchGetMetaProps, fetchGetMeta } from '@/services/meta/meta'
-import { QueryClient, useQueryClient } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import { CreateLinkFormValue } from '../LinkList'
 
 export interface UseCreateLinkReturnType {
-  isUrlCheck: boolean
-  setIsUrlCheck: Dispatch<SetStateAction<boolean>>
-  isUrlError: boolean
-  handleGetMeta: ({ url }: FetchGetMetaProps) => Promise<void>
   handleCreateLink: ({
     spaceId,
     url,
@@ -21,23 +15,8 @@ export interface UseCreateLinkReturnType {
   }: FetchCreateLinkProps) => Promise<void>
 }
 
-const useCreateLink = (
-  setValue: UseFormSetValue<CreateLinkFormValue>,
-): UseCreateLinkReturnType => {
+const useCreateLink = (): UseCreateLinkReturnType => {
   const queryclient = useQueryClient()
-  const [isUrlCheck, setIsUrlCheck] = useState(false)
-  const [isUrlError, setIsUrlError] = useState(false)
-
-  const handleGetMeta = async ({ url }: FetchGetMetaProps) => {
-    const { data, error } = await fetchGetMeta({
-      url,
-    })
-    setValue('title', data)
-    setIsUrlError(error)
-    if (error === false) {
-      setIsUrlCheck(true)
-    }
-  }
 
   const handleCreateLink = async ({
     spaceId,
@@ -57,10 +36,6 @@ const useCreateLink = (
   }
 
   return {
-    isUrlCheck,
-    setIsUrlCheck,
-    isUrlError,
-    handleGetMeta,
     handleCreateLink,
   }
 }

--- a/src/components/common/LinkList/hooks/useCreateLink.ts
+++ b/src/components/common/LinkList/hooks/useCreateLink.ts
@@ -1,13 +1,13 @@
 'use client'
 
-import { UseFormSetValue } from 'react-hook-form'
 import { FetchCreateLinkProps, fetchCreateLink } from '@/services/link/link'
 import { useQueryClient } from '@tanstack/react-query'
-import { CreateLinkFormValue } from '../LinkList'
 
+export interface UseCreateLinkProps {
+  spaceId?: number
+}
 export interface UseCreateLinkReturnType {
   handleCreateLink: ({
-    spaceId,
     url,
     title,
     tagName,
@@ -15,11 +15,12 @@ export interface UseCreateLinkReturnType {
   }: FetchCreateLinkProps) => Promise<void>
 }
 
-const useCreateLink = (): UseCreateLinkReturnType => {
+const useCreateLink = ({
+  spaceId,
+}: UseCreateLinkProps): UseCreateLinkReturnType => {
   const queryclient = useQueryClient()
 
   const handleCreateLink = async ({
-    spaceId,
     url,
     title,
     tagName,

--- a/src/components/common/LinkList/hooks/useGetMeta.ts
+++ b/src/components/common/LinkList/hooks/useGetMeta.ts
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { UseFormSetValue } from 'react-hook-form'
 import { FetchGetMetaProps, fetchGetMeta } from '@/services/meta/meta'
 import { CreateLinkFormValue } from '../LinkList'
+import { LINK_FORM_VALIDATION } from '../constants'
 
 export interface UseGetMetaProps {
   setValue: UseFormSetValue<CreateLinkFormValue>
@@ -25,7 +26,7 @@ const useGetMeta = ({ setValue, modalClose }: UseGetMetaProps) => {
     }
 
     if (error) {
-      setUrlErrorText('올바르지 않은 URL입니다.')
+      setUrlErrorText(LINK_FORM_VALIDATION.INCORRECT_URL)
     } else {
       setIsShowFormError(false)
       setIsUrlCheck(true)

--- a/src/components/common/LinkList/hooks/useGetMeta.ts
+++ b/src/components/common/LinkList/hooks/useGetMeta.ts
@@ -11,7 +11,7 @@ export interface UseGetMetaProps {
 const useGetMeta = ({ setValue, modalClose }: UseGetMetaProps) => {
   const [isUrlCheck, setIsUrlCheck] = useState(false)
   const [urlErrorText, setUrlErrorText] = useState('')
-  const [isShowTitleError, setIsShowTitleError] = useState(false)
+  const [isShowFormError, setIsShowFormError] = useState(false)
 
   const handleUrlValidation = ({
     data,
@@ -27,7 +27,7 @@ const useGetMeta = ({ setValue, modalClose }: UseGetMetaProps) => {
     if (error) {
       setUrlErrorText('올바르지 않은 URL입니다.')
     } else {
-      setIsShowTitleError(false)
+      setIsShowFormError(false)
       setIsUrlCheck(true)
       setUrlErrorText('')
     }
@@ -61,10 +61,11 @@ const useGetMeta = ({ setValue, modalClose }: UseGetMetaProps) => {
 
   return {
     isUrlCheck,
+    setIsUrlCheck,
     urlErrorText,
     setUrlErrorText,
-    isShowTitleError,
-    setIsShowTitleError,
+    isShowFormError,
+    setIsShowFormError,
     handleModalClose,
     handleChangeUrl,
     handleGetMeta,

--- a/src/components/common/LinkList/hooks/useGetMeta.ts
+++ b/src/components/common/LinkList/hooks/useGetMeta.ts
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+import { UseFormSetValue } from 'react-hook-form'
+import { FetchGetMetaProps, fetchGetMeta } from '@/services/meta/meta'
+import { CreateLinkFormValue } from '../LinkList'
+
+const useGetMeta = (setValue: UseFormSetValue<CreateLinkFormValue>) => {
+  const [isUrlCheck, setIsUrlCheck] = useState(false)
+  const [isUrlError, setIsUrlError] = useState(false)
+
+  const handleGetMeta = async ({ url }: FetchGetMetaProps) => {
+    const { data, error } = await fetchGetMeta({
+      url,
+    })
+    setValue('title', data)
+    setIsUrlError(error)
+    if (error === false) {
+      setIsUrlCheck(true)
+    }
+  }
+
+  return { isUrlCheck, setIsUrlCheck, isUrlError, handleGetMeta }
+}
+
+export default useGetMeta

--- a/src/components/common/LinkList/hooks/useGetMeta.ts
+++ b/src/components/common/LinkList/hooks/useGetMeta.ts
@@ -3,22 +3,72 @@ import { UseFormSetValue } from 'react-hook-form'
 import { FetchGetMetaProps, fetchGetMeta } from '@/services/meta/meta'
 import { CreateLinkFormValue } from '../LinkList'
 
-const useGetMeta = (setValue: UseFormSetValue<CreateLinkFormValue>) => {
+export interface UseGetMetaProps {
+  setValue: UseFormSetValue<CreateLinkFormValue>
+  modalClose: VoidFunction
+}
+
+const useGetMeta = ({ setValue, modalClose }: UseGetMetaProps) => {
   const [isUrlCheck, setIsUrlCheck] = useState(false)
-  const [isUrlError, setIsUrlError] = useState(false)
+  const [urlErrorText, setUrlErrorText] = useState('')
+  const [isShowTitleError, setIsShowTitleError] = useState(false)
+
+  const handleUrlValidation = ({
+    data,
+    error,
+  }: {
+    data: string
+    error: boolean
+  }) => {
+    if (data) {
+      setValue('title', data)
+    }
+
+    if (error) {
+      setUrlErrorText('올바르지 않은 URL입니다.')
+    } else {
+      setIsShowTitleError(false)
+      setIsUrlCheck(true)
+      setUrlErrorText('')
+    }
+  }
 
   const handleGetMeta = async ({ url }: FetchGetMetaProps) => {
     const { data, error } = await fetchGetMeta({
       url,
     })
-    setValue('title', data)
-    setIsUrlError(error)
-    if (error === false) {
-      setIsUrlCheck(true)
+
+    handleUrlValidation({ data, error })
+  }
+
+  const handleModalClose = () => {
+    modalClose()
+    setUrlErrorText('')
+    if (isUrlCheck) {
+      setIsUrlCheck(false)
     }
   }
 
-  return { isUrlCheck, setIsUrlCheck, isUrlError, handleGetMeta }
+  const handleChangeUrl = () => {
+    if (urlErrorText) {
+      setUrlErrorText('')
+    }
+
+    if (isUrlCheck) {
+      setIsUrlCheck(false)
+    }
+  }
+
+  return {
+    isUrlCheck,
+    urlErrorText,
+    setUrlErrorText,
+    isShowTitleError,
+    setIsShowTitleError,
+    handleModalClose,
+    handleChangeUrl,
+    handleGetMeta,
+  }
 }
 
 export default useGetMeta

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -33,11 +33,12 @@ const Modal = ({
 }: ModalProps) => {
   const rootNode = document.getElementById('root')
   const modalRef = useRef<HTMLDivElement | null>(null)
-  const { handleClickOverlay, handleClickConfirm } = useModalLogic({
-    onClose,
-    onConfirm,
-    modalRef,
-  })
+  const { handleClickOverlay, handleClickConfirm, handleSubmitConfirm } =
+    useModalLogic({
+      onClose,
+      onConfirm,
+      modalRef,
+    })
 
   return (
     <>
@@ -54,8 +55,8 @@ const Modal = ({
               )}>
               {type === 'form' ? (
                 <form
-                  onSubmit={() => {
-                    handleClickConfirm()
+                  onSubmit={(e) => {
+                    handleSubmitConfirm(e)
                   }}
                   className="flex flex-col gap-2">
                   <div className="flex items-center justify-between">

--- a/src/components/common/Modal/hooks/useModalLogic.ts
+++ b/src/components/common/Modal/hooks/useModalLogic.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react'
+import { FormEvent, useCallback, useEffect } from 'react'
 
 export interface useModalLogicProps {
   onClose: (e?: React.MouseEvent<HTMLButtonElement>) => void
@@ -9,6 +9,7 @@ export interface useModalLogicProps {
 export interface UseModalLogicReturnType {
   handleClickOverlay: (e: React.MouseEvent<HTMLDivElement>) => void
   handleClickConfirm: (e?: React.MouseEvent<HTMLButtonElement>) => void
+  handleSubmitConfirm: (e: FormEvent<HTMLFormElement>) => void
 }
 
 const useModalLogic = ({
@@ -46,7 +47,15 @@ const useModalLogic = ({
     [onConfirm, onClose],
   )
 
-  return { handleClickOverlay, handleClickConfirm }
+  const handleSubmitConfirm = useCallback(
+    (e: FormEvent<HTMLFormElement>) => {
+      e.preventDefault()
+      onConfirm?.()
+    },
+    [onConfirm],
+  )
+
+  return { handleClickOverlay, handleClickConfirm, handleSubmitConfirm }
 }
 
 export default useModalLogic

--- a/src/components/common/Space/hooks/useGetTags.ts
+++ b/src/components/common/Space/hooks/useGetTags.ts
@@ -1,5 +1,9 @@
-import { useCallback, useEffect, useState } from 'react'
 import { fetchGetTags } from '@/services/space/space'
+import {
+  QueryObserverResult,
+  RefetchOptions,
+  useQuery,
+} from '@tanstack/react-query'
 import { ChipColors } from '../../Chip/Chip'
 
 export interface Tag {
@@ -12,21 +16,23 @@ export interface UseGetTagsProps {
   spaceId?: number
 }
 
-const useGetTags = ({ spaceId }: UseGetTagsProps) => {
-  const [tags, setTags] = useState<Tag[]>()
+export type RefetchTagsType = (
+  options?: RefetchOptions | undefined,
+) => Promise<QueryObserverResult<any, Error>>
 
-  const handleGetTags = useCallback(async () => {
-    if (spaceId) {
-      const data = await fetchGetTags({ spaceId })
-      setTags(data.tags)
-    }
-  }, [spaceId])
+export interface UseGetTagsReturnType {
+  tags: Tag[]
+  refetchTags?: RefetchTagsType
+}
 
-  useEffect(() => {
-    handleGetTags()
-  }, [handleGetTags])
+const useGetTags = ({ spaceId }: UseGetTagsProps): UseGetTagsReturnType => {
+  const { data, refetch: refetchTags } = useQuery({
+    queryKey: ['tagList', spaceId],
+    queryFn: () => fetchGetTags({ spaceId }),
+    enabled: !!spaceId,
+  })
 
-  return { tags }
+  return { tags: data?.tags, refetchTags }
 }
 
 export default useGetTags

--- a/src/components/common/Space/hooks/useGetTags.ts
+++ b/src/components/common/Space/hooks/useGetTags.ts
@@ -12,13 +12,13 @@ export interface Tag {
   tagId: number
 }
 
-export interface UseGetTagsProps {
-  spaceId?: number
-}
-
 export type RefetchTagsType = (
   options?: RefetchOptions | undefined,
 ) => Promise<QueryObserverResult<any, Error>>
+
+export interface UseGetTagsProps {
+  spaceId?: number
+}
 
 export interface UseGetTagsReturnType {
   tags: Tag[]

--- a/src/components/common/SpaceMemberList/SpaceMemberList.tsx
+++ b/src/components/common/SpaceMemberList/SpaceMemberList.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components'
 import { useModal } from '@/hooks'
 import { UserDetailInfo } from '@/types'
 import { PlusSmallIcon } from '@heroicons/react/24/solid'
+import { useRouter } from 'next/navigation'
 import Avatar from '../Avatar/Avatar'
 import Button from '../Button/Button'
 import Dropdown from '../Dropdown/Dropdown'
@@ -16,6 +17,7 @@ export interface SpaceMemberListProps {
 }
 
 const SpaceMemberList = ({ members, edit = false }: SpaceMemberListProps) => {
+  const router = useRouter()
   const { Modal, isOpen, modalOpen, modalClose } = useModal(false)
 
   const handleConfirm = () => {
@@ -75,7 +77,11 @@ const SpaceMemberList = ({ members, edit = false }: SpaceMemberListProps) => {
               />
             )}
 
-            <div className="text-sm font-semibold">{member.nickname}</div>
+            <div
+              onClick={() => router.push(`/user/${member.memberId}`)}
+              className="cursor-pointer text-sm font-semibold">
+              {member.nickname}
+            </div>
           </div>
           {member.SpaceMemberRole === 'OWNER' ? (
             <DropdownItem

--- a/src/services/link/link.ts
+++ b/src/services/link/link.ts
@@ -48,7 +48,7 @@ const fetchCreateLink = async ({
 }
 
 export interface FetchUpdateLinkProps extends CreateLinkReqBody {
-  spaceId: number
+  spaceId?: number
   linkId: number
 }
 

--- a/src/services/link/link.ts
+++ b/src/services/link/link.ts
@@ -37,7 +37,13 @@ const fetchCreateLink = async ({
   color,
 }: FetchCreateLinkProps) => {
   const path = `/api/space/${spaceId}/links`
-  const body = { spaceId, url, title, tagName, color }
+  const body = {
+    spaceId,
+    url,
+    title,
+    ...(tagName && { tagName }),
+    ...(color && { color }),
+  }
 
   try {
     const response = await apiClient.post(path, body)

--- a/src/services/link/link.ts
+++ b/src/services/link/link.ts
@@ -47,6 +47,30 @@ const fetchCreateLink = async ({
   }
 }
 
+export interface FetchUpdateLinkProps extends CreateLinkReqBody {
+  spaceId: number
+  linkId: number
+}
+
+const fetchUpdateLink = async ({
+  spaceId,
+  linkId,
+  url,
+  title,
+  tagName,
+  color,
+}: FetchUpdateLinkProps) => {
+  const path = `/api/space/${spaceId}/links`
+  const body = { spaceId, linkId, url, title, tagName, color }
+
+  try {
+    const response = await apiClient.put(path, body)
+    return response
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
+}
+
 export interface FetchDeleteLinkProps {
   spaceId: number
   linkId: number
@@ -83,7 +107,6 @@ const fetchLikeLink = async ({ linkId }: FetchLikeLinkProps) => {
   }
 }
 
-
 const fetchUnLikeLink = async ({ linkId }: FetchLikeLinkProps) => {
   const path = `/api/links/${linkId}/like`
 
@@ -119,6 +142,7 @@ const fetchReadSaveLink = async ({
 export {
   fetchGetLinks,
   fetchCreateLink,
+  fetchUpdateLink,
   fetchDeleteLink,
   fetchLikeLink,
   fetchUnLikeLink,


### PR DESCRIPTION
## 📑 이슈 번호
#105 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 링크 수정 api를 연결 및 구현하였습니다.
- 링크 생성, 수정, 삭제 시 현재 태그 목록을 업데이트 하도록 구현하였습니다.
- 링크 생성, 수정 폼에 Validation을 적용하였습니다.
- 스페이스의 멤버가 링크를 클릭했을 때만 접속 이력 api가 호출되도록 수정하였습니다.
- 링크 접속 정보 프로필 이미지를 적용하였습니다.
- 스페이스 상세 조회 페이지에서 멤버 리스트 닉네임 클릭 시 프로필 페이지로 이동하도록 수정하였습니다.

### 링크 생성 폼
![Nov-27-2023 16-22-32](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/746d921b-1a66-43ba-a071-c63665465f2e)

<br>

### 링크 수정 폼
![Nov-27-2023 16-28-07](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/e2a6e410-8f25-4c3a-9692-29135b9fdf30)


## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### useGetTags 변경점
태그 목록 조회 api를 react-query로 호출하는 로직으로 변경하였습니다.
태그 목록을 업데이트 하시려면 `refetchTags`를 사용하시면 됩니다.
```tsx
const useGetTags = ({ spaceId }: UseGetTagsProps): UseGetTagsReturnType => {
  const { data, refetch: refetchTags } = useQuery({
    queryKey: ['tagList', spaceId],
    queryFn: () => fetchGetTags({ spaceId }),
    enabled: !!spaceId,
  })

  return { tags: data?.tags, refetchTags }
}
```