### PR TITLE
스페이스 초대 알림 조회 api 연결

### DIFF
--- a/src/app/(routes)/notification/invite/page.tsx
+++ b/src/app/(routes)/notification/invite/page.tsx
@@ -1,29 +1,14 @@
 'use client'
 
-import { Notification } from '@/components'
-import { mock_notificationInviteData } from '@/data'
+import NotificationList from '@/components/common/NotificationList/NotificationList'
+import { fetchGetInvitations } from '@/services/notification/invitations'
 
 const NotificationInvitePage = () => {
-  const notifications = mock_notificationInviteData
-
   return (
-    <div className="flex flex-col gap-2">
-      {notifications.map((notification) => (
-        <Notification
-          key={notification.id}
-          notificationId={notification.id}
-          type={notification.type}
-          userId={notification.userId}
-          userName={notification.userName}
-          spaceId={notification.spaceId}
-          spaceName={notification.spaceName}
-          isRead={notification.isRead}
-          isAccept={notification.isAccept}
-          onAccept={() => console.log('스페이스 수락')}
-          onClose={() => console.log('알람 닫기')}
-        />
-      ))}
-    </div>
+    <NotificationList
+      fetchFn={fetchGetInvitations}
+      type={'INVITATION'}
+    />
   )
 }
 

--- a/src/app/(routes)/notification/page.tsx
+++ b/src/app/(routes)/notification/page.tsx
@@ -10,14 +10,14 @@ const NotificationPage = () => {
     <div className="flex flex-col gap-2">
       {notifications.map((notification) => (
         <Notification
-          key={notification.id}
           notificationId={notification.id}
-          type={notification.type}
+          notificationType={notification.notificationType}
           userId={notification.userId}
           userName={notification.userName}
           spaceId={notification.spaceId}
           spaceName={notification.spaceName}
           isRead={notification.isRead}
+          key={notification.id}
           onClose={() => console.log('알람 닫기')}
         />
       ))}

--- a/src/app/api/notification/invitations/route.ts
+++ b/src/app/api/notification/invitations/route.ts
@@ -1,0 +1,22 @@
+import { useServerCookie } from '@/hooks/useServerCookie'
+import { apiServer } from '@/services/apiServices'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const { token } = useServerCookie()
+  const { searchParams } = new URL(req.url)
+  const path = '/notifications/invitations'
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  }
+
+  try {
+    const data = await apiServer.get(`${path}?${searchParams}`, {}, headers)
+    return NextResponse.json(data)
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.message },
+      { status: error.response.status },
+    )
+  }
+}

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -56,7 +56,7 @@ const Header = () => {
         </div>
         <div className="flex items-center justify-center gap-x-1">
           <Button className="flex h-8 w-8 items-center justify-center">
-            <Link href="/notification">
+            <Link href="/notification/invite">
               <BellIcon className="h-6 w-6 text-slate9" />
             </Link>
           </Button>

--- a/src/components/common/Notification/Notification.tsx
+++ b/src/components/common/Notification/Notification.tsx
@@ -8,26 +8,26 @@ import useNotification from './hooks/useNotification'
 
 export interface NotificationProps {
   notificationId: number
-  type: 'follow' | 'comment' | 'space'
+  notificationType: 'FOLLOW' | 'COMMENT' | 'INVITATION'
   userId: number
   userName: string
   spaceId?: number
   spaceName?: string
   isRead?: boolean
-  isAccept?: boolean
+  isAccepted?: boolean
   onAccept?: (e?: React.MouseEvent<HTMLButtonElement>) => void
   onClose?: (e?: React.MouseEvent<HTMLButtonElement>) => void
 }
 
 const Notification = ({
   notificationId,
-  type,
+  notificationType,
   userId,
   userName,
   spaceId,
   spaceName,
   isRead = false,
-  isAccept = false,
+  isAccepted = false,
   onAccept,
   onClose,
 }: NotificationProps) => {
@@ -38,7 +38,7 @@ const Notification = ({
     <div
       className={cls(
         'flex flex-col gap-6 rounded-md border border-slate3 p-3',
-        isRead ? 'bg-bgColor' : 'bg-emerald05',
+        isRead || isAccepted ? 'bg-bgColor' : 'bg-emerald05',
       )}>
       <div className="flex w-full items-start justify-between text-sm font-medium text-gray9">
         <div>
@@ -48,7 +48,7 @@ const Notification = ({
             {userName}
           </span>
           {NOTIFICATION_MSG.USER}
-          {type === 'follow' ? (
+          {notificationType === 'FOLLOW' ? (
             NOTIFICATION_MSG.FOLLOW
           ) : (
             <>
@@ -60,7 +60,7 @@ const Notification = ({
                 {spaceName}
               </span>
               {NOTIFICATION_MSG.SPACE}
-              {type === 'comment' ? (
+              {notificationType === 'COMMENT' ? (
                 <>
                   <span
                     onClick={() =>
@@ -85,9 +85,9 @@ const Notification = ({
           <XMarkIcon className="h-5 w-5 p-0.5 text-slate6" />
         </Button>
       </div>
-      {type === 'space' && (
+      {notificationType === 'INVITATION' && (
         <div className="flex justify-end">
-          {isAccept ? (
+          {isAccepted ? (
             <div className="text-sm font-semibold text-slate6">
               {NOTIFICATION_MSG.APPROVE}
             </div>

--- a/src/components/common/Notification/Notification.tsx
+++ b/src/components/common/Notification/Notification.tsx
@@ -59,7 +59,7 @@ const Notification = ({
                 className="cursor-pointer font-bold">
                 {spaceName}
               </span>
-              {NOTIFICATION_MSG.SPACE}
+              {NOTIFICATION_MSG.TO}
               {notificationType === 'COMMENT' ? (
                 <>
                   <span

--- a/src/components/common/Notification/constants/index.ts
+++ b/src/components/common/Notification/constants/index.ts
@@ -3,8 +3,8 @@ export const NOTIFICATION_MSG = {
   APPROVE: '수락 완료',
   USER: ' 님이 ',
   FOLLOW: '팔로우했습니다.',
+  TO: '에 ',
   COMMENT: '댓글',
   COMMENT_LEAVE: '을 남겼습니다.',
-  SPACE: ' 스페이스에 ',
   SPACE_INVITE: '초대했습니다.',
 }

--- a/src/components/common/NotificationList/NotificationList.tsx
+++ b/src/components/common/NotificationList/NotificationList.tsx
@@ -1,0 +1,48 @@
+import { Fragment } from 'react'
+import useInfiniteScroll from '@/hooks/useInfiniteScroll'
+import { InvitationsNotification, InvitationsReqBody } from '@/types'
+import Notification from '../Notification/Notification'
+import useNotificationQuery from './hooks/useNotificationQuery'
+
+export interface NotificationListProps {
+  fetchFn: ({ pageNumber, pageSize }: InvitationsReqBody) => Promise<any>
+  type: 'FOLLOW' | 'COMMENT' | 'INVITATION'
+}
+
+const NotificationList = ({ fetchFn, type }: NotificationListProps) => {
+  const { notificationList, fetchNextPage, hasNextPage } = useNotificationQuery(
+    {
+      fetchFn,
+      type,
+    },
+  )
+  const { target } = useInfiniteScroll({ hasNextPage, fetchNextPage })
+
+  return (
+    <ul className="flex flex-col gap-y-2">
+      {notificationList?.pages.map((group, i) => (
+        <Fragment key={i}>
+          {group.responses?.map((notification: InvitationsNotification) => (
+            <li key={notification.notificationId}>
+              <Notification
+                notificationId={notification.notificationId}
+                notificationType={notification.notificationType}
+                userId={notification.invitingMemberId}
+                userName={notification.invitingMemberName}
+                spaceId={notification.spaceId}
+                spaceName={notification.spaceName}
+                isAccepted={notification.isAccepted}
+                onAccept={() => console.log('스페이스 수락')}
+                onClose={() => console.log('알람 닫기')}
+                key={notification.notificationId}
+              />
+            </li>
+          ))}
+        </Fragment>
+      ))}
+      <div ref={target}></div>
+    </ul>
+  )
+}
+
+export default NotificationList

--- a/src/components/common/NotificationList/hooks/useNotificationQuery.ts
+++ b/src/components/common/NotificationList/hooks/useNotificationQuery.ts
@@ -1,0 +1,22 @@
+import { FollowListProps } from '@/components/common/FollowList/FollowList'
+import { INITIAL_PAGE_NUMBER, PAGE_SIZE } from '@/constants'
+import { useInfiniteQuery } from '@tanstack/react-query'
+
+const useNotificationQuery = ({ fetchFn, type }: FollowListProps) => {
+  const queryKey = type
+  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
+    queryKey: [queryKey],
+    queryFn: ({ pageParam }) =>
+      fetchFn({
+        pageNumber: pageParam,
+        pageSize: PAGE_SIZE,
+      }),
+    initialPageParam: INITIAL_PAGE_NUMBER,
+    getNextPageParam: (lastPage) =>
+      lastPage.metaData?.hasNext ? lastPage.metaData.pageNumber + 1 : undefined,
+  })
+
+  return { notificationList: data, fetchNextPage, hasNextPage }
+}
+
+export default useNotificationQuery

--- a/src/components/common/Tab/constants/index.ts
+++ b/src/components/common/Tab/constants/index.ts
@@ -1,12 +1,12 @@
 export const NOTIFICATION_TAB_LIST = [
   {
-    text: '알림',
-    content: 'notification',
-    dest: `/notification`,
-  },
-  {
     text: '초대',
     content: 'invite',
     dest: `/notification/invite`,
+  },
+  {
+    text: '알림',
+    content: 'notification',
+    dest: `/notification`,
   },
 ]

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -387,7 +387,7 @@ export const mock_spaceData = {
 
 export const mock_notificationData: {
   id: number
-  type: 'comment' | 'follow' | 'space'
+  notificationType: 'COMMENT' | 'FOLLOW' | 'INVITATION'
   userId: number
   userName: string
   spaceId?: number
@@ -397,14 +397,14 @@ export const mock_notificationData: {
 }[] = [
   {
     id: 1,
-    type: 'follow',
+    notificationType: 'FOLLOW',
     userId: 1,
     userName: '프롱이',
     isRead: false,
   },
   {
     id: 2,
-    type: 'comment',
+    notificationType: 'COMMENT',
     userId: 1,
     userName: '프롱이',
     spaceId: 123,
@@ -414,7 +414,7 @@ export const mock_notificationData: {
   },
   {
     id: 3,
-    type: 'comment',
+    notificationType: 'COMMENT',
     userId: 1,
     userName: '백둥이',
     spaceId: 456,
@@ -424,14 +424,14 @@ export const mock_notificationData: {
   },
   {
     id: 4,
-    type: 'follow',
+    notificationType: 'FOLLOW',
     userId: 1,
     userName: '백둥이',
     isRead: true,
   },
   {
     id: 5,
-    type: 'comment',
+    notificationType: 'COMMENT',
     userId: 1,
     userName: '풀택이',
     spaceId: 789,

--- a/src/services/notification/invitations.ts
+++ b/src/services/notification/invitations.ts
@@ -1,0 +1,23 @@
+import { InvitationsReqBody } from '@/types'
+import { apiClient } from '../apiServices'
+
+const fetchGetInvitations = async ({
+  pageNumber,
+  pageSize,
+}: InvitationsReqBody) => {
+  const path = '/api/notification/invitations'
+  const params = {
+    pageNumber: pageNumber.toString(),
+    pageSize: pageSize.toString(),
+  }
+  const queryString = new URLSearchParams(params).toString()
+
+  try {
+    const response = await apiClient.get(`${path}?${queryString}`)
+    return response
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
+}
+
+export { fetchGetInvitations }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -230,3 +230,18 @@ export interface SearchUserReqBody {
   pageSize: number
   keyword: string
 }
+
+export interface InvitationsReqBody {
+  pageNumber: number
+  pageSize: number
+}
+
+export interface InvitationsNotification {
+  notificationId: number
+  notificationType: 'FOLLOW' | 'COMMENT' | 'INVITATION'
+  invitingMemberId: number
+  invitingMemberName: string
+  spaceId: number
+  spaceName: string
+  isAccepted: boolean
+}


### PR DESCRIPTION
## 📑 이슈 번호
#178 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 스페이스 초대 알림 조회 api를 연결 및 구현하였습니다.
- 무한 스크롤을 통해 10개씩 보이도록 적용하였습니다.
- 헤더의 알림 아이콘을 클릭할 때 초대 페이지로 이동하도록 변경하였습니다. (발표 전 임시로 변경)
- 알림 페이지의 탭 순서를 변경하였습니다. (초대를 앞으로)

![Nov-29-2023 03-25-22](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/5359d980-dfb5-4f8c-9977-619f16c9997c)


## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
스페이스 초대 알림 문구를 "~ 님이 ~에 초대했습니다." 로 변경하는 것이 좋을까요?
영상처럼 스페이스 이름에 "스페이스"가 붙으면 "스페이스 스페이스에 초대했습니다." 라고 보여져서요..!