### PR TITLE
모달 외부 스크롤이 동작하는 버그 수정

### DIFF
--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { LinkIcon } from '@heroicons/react/20/solid'
 import { BellIcon } from '@heroicons/react/24/outline'
 import { MagnifyingGlassCircleIcon } from '@heroicons/react/24/outline'
@@ -40,6 +40,14 @@ const Header = () => {
     },
     [searchParams],
   )
+
+  useEffect(() => {
+    if (isSidebarOpen || isSearchModalOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'auto'
+    }
+  }, [isSidebarOpen, isSearchModalOpen])
 
   return (
     <>

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Modal } from '@/components'
 
 export interface UseModalReturnType {
@@ -24,6 +24,14 @@ const useModal = (initialState = false): UseModalReturnType => {
     },
     [modalOpen],
   )
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'auto'
+    }
+  }, [isOpen])
 
   return {
     Modal,


### PR DESCRIPTION
## 📑 이슈 번호
#184 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 중앙 모달, 사이드바 모달, 검색 모달을 사용할 때 뒷배경이 스크롤 되지 않도록 수정하였습니다.

![Nov-29-2023 15-16-21](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/6a38ba5d-dadc-462d-9609-0151accd9755)
## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
