### PR TITLE
스페이스폼, 유저폼 validation 추가

### DIFF
--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -68,6 +68,7 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
   const handleConfirm = async () => {
     try {
       await fetchDeleteSpace(spaceId)
+      alert('삭제하였습니다.')
       router.replace('/')
     } catch (e) {
       alert('스페이스 삭제에 실패하였습니다.')
@@ -79,8 +80,8 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
       className="flex flex-col gap-3"
       onSubmit={handleSubmit(async (data) => {
         if (spaceType === 'Create') {
-          await feachCreateSpace(data, imageFile)
-          router.replace('/')
+          const { spaceId } = await feachCreateSpace(data, imageFile)
+          router.replace(`/space/${spaceId}`)
         } else if (spaceType === 'Setting') {
           await fetchSettingSpace(spaceId, data, imageFile)
           router.back()
@@ -117,6 +118,14 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
           <Input
             {...register('spaceName', {
               required: '스페이스명을 입력해 주세요',
+              minLength: {
+                value: 2,
+                message: '스페이스명은 최소 2글자 이상이어야 합니다.',
+              },
+              maxLength: {
+                value: 20,
+                message: '스페이스명은 20글자 이하여야 합니다.',
+              },
             })}
             label="스페이스 이름"
             placeholder="스페이스 이름을 입력하세요"
@@ -126,10 +135,16 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
         </div>
         <div>
           <Input
-            {...register('description')}
+            {...register('description', {
+              maxLength: {
+                value: 40,
+                message: '스페이스 설명은 40글자 이하여야 합니다.',
+              },
+            })}
             label="스페이스 설명"
             placeholder="스페이스 설명을 입력하세요"
             type="text"
+            validation={errors.description?.message}
           />
         </div>
         <div className="flex flex-col gap-2">

--- a/src/components/UserInfoForm/UserInfoForm.tsx
+++ b/src/components/UserInfoForm/UserInfoForm.tsx
@@ -43,6 +43,7 @@ const UserInfoForm = ({ userData, formType }: UserInfoFormProps) => {
 
   const emailRegex =
     /^[a-zA-Z0-9.!#$%&'*+/=?&_`{|}~-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-]/
+  const nickNameRegex = /^[a-zA-Zㄱ-힣0-9]*$/
 
   const {
     register,
@@ -168,23 +169,46 @@ const UserInfoForm = ({ userData, formType }: UserInfoFormProps) => {
         <Input
           {...register('nickname', {
             required: '닉네임을 입력해 주세요',
+            minLength: {
+              value: 2,
+              message: '닉네임은 최소 2글자 이상이어야 합니다.',
+            },
+            maxLength: {
+              value: 10,
+              message: '닉네임은 10글자 이하여야 합니다.',
+            },
+            pattern: nickNameRegex,
           })}
           label="닉네임"
           placeholder="nickname"
-          validation={errors.nickname?.message}
+          validation={
+            errors.nickname?.type === 'pattern'
+              ? '닉네임에는 공백이나 특수문자를 사용할 수 없습니다.'
+              : errors.nickname?.message
+          }
         />
       </div>
       <div>
         <Input
-          {...register('aboutMe')}
+          {...register('aboutMe', {
+            maxLength: {
+              value: 50,
+              message: '한줄 소개는 50글자 이하여야 합니다.',
+            },
+          })}
           label="한줄 소개"
           placeholder="aboutMe"
+          validation={errors.aboutMe?.message}
         />
       </div>
       <div>
         <Input
           {...register('newsEmail', {
             required: '이메일을 입력해 주세요',
+            maxLength: {
+              value: 300,
+              message: '이메일의 길이가 너무 깁니다.',
+            },
             pattern: emailRegex,
           })}
           validation={


### PR DESCRIPTION
## 📑 이슈 번호
#180 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
### 스페이스폼, 유저폼에 validation을 추가하였습니다.

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### 추가된 validation
1. 유저 닉네임은 2자 이상 10자 이하입니다.
2. 유저 닉네임에는 특수문자 및 공백이 포함될 수 없습니다.
3. 유저 한줄 소개는 50자 이하입니다.
4. 유저 이메일은 300자 이하입니다.
5. 스페이스명은 2자 이상 20자 이하입니다.
6. 스페이스 설명은 40자 이하입니다.

### 그 외 변경사항
- 스페이스 생성
  - 변경 전 : 스페이스를 생성하면 메인 화면으로 이동
  - 변경 후 : 스페이스를 생성하면 생성된 스페이스로 이동