### PR TITLE
댓글 폼 validation 토스트 적용

### DIFF
--- a/src/app/(routes)/space/[spaceId]/comment/page.tsx
+++ b/src/app/(routes)/space/[spaceId]/comment/page.tsx
@@ -35,6 +35,7 @@ const SpaceCommentPage = ({ params }: { params: { spaceId: number } }) => {
     handleReply,
     handleCancel,
     onSubmit,
+    onSubmitError,
   } = useSpaceComment({
     spaceId: params.spaceId,
     setValue,
@@ -83,7 +84,7 @@ const SpaceCommentPage = ({ params }: { params: { spaceId: number } }) => {
       </section>
       <form
         className="fixed bottom-0 z-10 w-full max-w-[500px] bg-bgColor"
-        onSubmit={handleSubmit(onSubmit)}>
+        onSubmit={handleSubmit(onSubmit, onSubmitError)}>
         {comment.type === 'reply' && (
           <div className="flex items-center justify-between border-t border-slate3 px-4 py-2 text-xs font-medium text-gray6">
             <span>
@@ -114,12 +115,18 @@ const SpaceCommentPage = ({ params }: { params: { spaceId: number } }) => {
         )}
         <div className="border-t border-slate3 px-4 py-3">
           <Input
-            {...register('content', { required: true, maxLength: 1000 })}
+            {...register('content', {
+              required: true,
+              maxLength: {
+                value: 1000,
+                message: '댓글은 1000자 이하로 작성해야 합니다.',
+              },
+            })}
             inputButton={true}
             buttonText="작성"
             buttonType="submit"
             buttonColor="gray"
-            placeholder="댓글을 작성해 주세요"
+            placeholder="댓글을 작성해 주세요 (1000자 이하)"
           />
         </div>
       </form>

--- a/src/components/common/Comment/Comment.tsx
+++ b/src/components/common/Comment/Comment.tsx
@@ -58,12 +58,14 @@ const Comment = ({
   return (
     <>
       <article className="flex gap-x-2 py-3">
-        <Avatar
-          src={profileImagePath}
-          width={30}
-          height={30}
-          alt={nickname}
-        />
+        {profileImagePath && (
+          <Avatar
+            src={profileImagePath}
+            width={30}
+            height={30}
+            alt={nickname}
+          />
+        )}
         <div className="flex w-full flex-col gap-y-1">
           <div className="flex items-center justify-between">
             <Link

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -44,9 +44,10 @@ const Input = forwardRef(
             type={type}
             className={cls(
               'rounded-md border bg-bgColor px-3 py-2.5 text-sm font-medium text-gray9 placeholder-gray4 outline-none disabled:border-gray3 disabled:text-gray3 disabled:placeholder-gray3',
-              inputButton && buttonColor === 'green'
-                ? 'border-emerald6 pr-20'
-                : 'border-slate5',
+              inputButton &&
+                (buttonColor === 'green'
+                  ? 'border-emerald6 pr-20'
+                  : 'border-slate5 pr-20'),
             )}
             placeholder={placeholder}
             disabled={disabled}

--- a/src/hooks/useSpaceComment.ts
+++ b/src/hooks/useSpaceComment.ts
@@ -1,11 +1,13 @@
 import { useCallback, useRef, useState } from 'react'
 import {
+  SubmitErrorHandler,
   SubmitHandler,
   UseFormSetFocus,
   UseFormSetValue,
 } from 'react-hook-form'
 import { CommentFormValues } from '@/app/(routes)/space/[spaceId]/comment/page'
 import { CommentProps } from '@/components/common/Comment/Comment'
+import { notify } from '@/components/common/Toast/Toast'
 import {
   fetchCreateComment,
   fetchUpdateComment,
@@ -122,6 +124,12 @@ const useSpaceComment = ({
     setValue('content', '')
   }
 
+  const onSubmitError: SubmitErrorHandler<CommentFormValues> = ({
+    content,
+  }) => {
+    content?.message && notify('error', content?.message)
+  }
+
   return {
     comment,
     openedComments,
@@ -131,6 +139,7 @@ const useSpaceComment = ({
     handleReply,
     handleCancel,
     onSubmit,
+    onSubmitError,
   }
 }
 


### PR DESCRIPTION
## 📑 이슈 번호
- close #180 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 댓글 폼 validation에 토스트를 적용했습니다. (1000자 이하)

https://github.com/Team-TenTen/LinkHub-FE/assets/49032882/a1518153-9678-417d-ac7a-5d874fad6cb8


## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### Comment 컴포넌트
- 탈퇴한 유저인 경우 `profileImagePath: null` 이라서 아바타를 아예 보여주지 않게끔 예외 처리했습니다.
  - 🔗 [Comment 컴포넌트 profileImagePath null 값 예외 처리](https://github.com/Team-TenTen/LinkHub-FE/commit/974877aec3214652d56a2e8f90701a0521a1c8ab)
  - 지금은 탈퇴한 유저의 댓글에 대댓글을 달 수 있으나 추후 논의가 필요합니다.

### Input 컴포넌트
- 버튼에 인풋 텍스트가 가려져 `inputButton = true`인 경우 padding-right를 추가했습니다.
  - 🔗 [Input 컴포넌트 inputButton true인 경우 padding-right 추가](https://github.com/Team-TenTen/LinkHub-FE/commit/ed37d417c0573d467bfbf62677d1ff74704ad48d)