### PR TITLE
fetch error handler 추가

### DIFF
--- a/src/app/api/space/[spaceId]/route.ts
+++ b/src/app/api/space/[spaceId]/route.ts
@@ -54,7 +54,7 @@ export async function DELETE(req: NextRequest) {
 
   try {
     const response = await apiServer.delete(path, {}, headers)
-    return NextResponse.json(response)
+    return response
   } catch (error: any) {
     return NextResponse.json(
       { error: error.response.data.message },

--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -72,7 +72,7 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
       notify('info', '스페이스가 삭제되었습니다.')
       router.replace('/')
     } catch (e) {
-      notify('error', '스페이스 삭제에 실패하였습니다.')
+      router.push('/')
     }
   }
 
@@ -81,29 +81,21 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
       className="flex flex-col gap-3"
       onSubmit={handleSubmit(async (data) => {
         if (spaceType === 'Create') {
-          try {
-            const { spaceId } = await feachCreateSpace(data, imageFile)
-            notify('info', '스페이스가 생성되었습니다.')
-            router.replace(`/space/${spaceId}`)
-          } catch (e) {
-            notify('error', '스페이스 생성에 실패했습니다.')
-          }
+          const { spaceId } = await feachCreateSpace(data, imageFile)
+          notify('info', '스페이스가 생성되었습니다.')
+          router.replace(`/space/${spaceId}`)
         } else if (spaceType === 'Setting') {
           try {
             await fetchSettingSpace(spaceId, data, imageFile)
             notify('info', '스페이스를 수정했습니다.')
             router.back()
           } catch (e) {
-            notify('error', '스페이스 수정에 실패했습니다.')
+            router.replace('/')
           }
         } else {
-          try {
-            const response = await fetchScrapSpace(spaceId, data, imageFile)
-            notify('info', '스페이스가 생성되었습니다.')
-            router.push(`/space/${response.spaceId}`)
-          } catch (e) {
-            notify('error', '스페이스 생성에 실패했습니다.')
-          }
+          const response = await fetchScrapSpace(spaceId, data, imageFile)
+          notify('info', '스페이스가 생성되었습니다.')
+          router.push(`/space/${response.spaceId}`)
         }
       })}>
       <div>

--- a/src/components/UserInfoForm/UserInfoForm.tsx
+++ b/src/components/UserInfoForm/UserInfoForm.tsx
@@ -11,6 +11,7 @@ import { CheckIcon } from '@heroicons/react/24/solid'
 import { useRouter } from 'next/navigation'
 import Button from '../common/Button/Button'
 import { CATEGORIES } from '../common/CategoryList/constants'
+import { notify } from '../common/Toast/Toast'
 import useToggle from '../common/Toggle/hooks/useToggle'
 import { RegisterReqBody, useRegister } from './hooks/useRegister'
 
@@ -77,31 +78,20 @@ const UserInfoForm = ({ userData, formType }: UserInfoFormProps) => {
 
   const handleEmailAuth = async (email: string) => {
     try {
-      const response = await fetchPostEmail({ email })
-
-      if (response.errorCode === 'M001') {
-        alert('이미 인증된 이메일 입니다.')
-        setVerification(true)
-        return
-      }
-
-      setIsEmailAuthOpen(true)
+      await fetchPostEmail({ email })
+      notify('success', '인증번호를 발송했습니다.')
     } catch (e) {
-      alert('이메일을 다시 확인해 주세요')
+      setVerification(true)
     }
   }
 
   const handleCheckAuthNum = async (code: string) => {
-    try {
-      const verification = await fetchPostEmailVerify({
-        email: getValues('newsEmail'),
-        code,
-      })
-      setVerification(verification.isVerificate)
-      alert('인증되었습니다!')
-    } catch (e) {
-      alert('인증번호를 다시 확인해 주세요')
-    }
+    const verification = await fetchPostEmailVerify({
+      email: getValues('newsEmail'),
+      code,
+    })
+    setVerification(verification.isVerificate)
+    notify('success', '인증되었습니다.')
   }
 
   const handleClickCheckButton = () => {
@@ -112,31 +102,23 @@ const UserInfoForm = ({ userData, formType }: UserInfoFormProps) => {
   const handleRegisterLinkHub = async (
     data: RegisterReqBody & EmailVerifyReqBody,
   ) => {
-    try {
-      await registerLinkHub(data, imageFile)
-      alert('회원가입 되었습니다!')
-      router.replace('/login')
-    } catch (e) {
-      alert('회원가입에 실패했습니다.')
-    }
+    await registerLinkHub(data, imageFile)
+    notify('success', '회원가입 되었습니다.')
+    router.replace('/login')
   }
 
   const handleSettingUser = async (
     data: RegisterReqBody & EmailVerifyReqBody,
   ) => {
-    try {
-      userData?.memberId &&
-        (await fetchPostUserProfile(userData?.memberId, data, imageFile))
-      alert('수정되었습니다!')
-      router.back()
-    } catch (e) {
-      alert('정보 수정에 실패했습니다.')
-    }
+    userData?.memberId &&
+      (await fetchPostUserProfile(userData?.memberId, data, imageFile))
+    notify('success', '수정되었습니다.')
+    router.back()
   }
 
   const handleWithdrawButton = () => {
     // Todo: 회원탈퇴 로직
-    alert('미구현된 기능입니다.')
+    notify('info', '미구현된 기능입니다.')
   }
 
   return (

--- a/src/lib/fetchAPI.ts
+++ b/src/lib/fetchAPI.ts
@@ -1,3 +1,5 @@
+import { notify } from '@/components/common/Toast/Toast'
+
 class FetchAPI {
   private baseURL: string
   private headers: { [key: string]: string }
@@ -9,6 +11,39 @@ class FetchAPI {
     this.headers = {
       'Content-Type': 'application/json;charset=UTF-8',
     }
+  }
+
+  private async responseHandler(response: Response) {
+    if (!response.ok) {
+      const data = await response.json()
+      switch (response.status) {
+        case 401:
+          notify(
+            'error',
+            `${data.errorMessage}` || '인증되지 않은 사용자입니다.',
+          )
+          break
+        case 404:
+          notify(
+            'error',
+            `${data.errorMessage}` || '해당하는 요청을 찾을 수 없습니다.',
+          )
+          break
+        case 500:
+          notify(
+            'error',
+            `${data.errorMessage}` || '서버에 오류가 발생했습니다.',
+          )
+          break
+        default:
+          notify(
+            'error',
+            `${data.errorMessage}` || '알 수 없는 오류가 발생했습니다.',
+          )
+          break
+      }
+    }
+    return response.json()
   }
 
   public static getInstance(): FetchAPI {
@@ -36,8 +71,7 @@ class FetchAPI {
       headers: { ...this.headers, ...customHeaders },
       ...nextInit,
     })
-    const data = response.json()
-    return data
+    return this.responseHandler(response)
   }
 
   public async post(
@@ -56,8 +90,7 @@ class FetchAPI {
       body: type === 'multipart' ? body : JSON.stringify(body),
       ...nextInit,
     })
-    const data = response.json()
-    return data
+    return this.responseHandler(response)
   }
 
   public async put(
@@ -76,8 +109,7 @@ class FetchAPI {
       body: type === 'multipart' ? body : JSON.stringify(body),
       ...nextInit,
     })
-    const data = response.json()
-    return data
+    return this.responseHandler(response)
   }
 
   public async delete(
@@ -90,7 +122,7 @@ class FetchAPI {
       headers: { ...this.headers, ...customHeaders },
       ...nextInit,
     })
-    return response
+    return this.responseHandler(response)
   }
 
   public async patch(
@@ -109,8 +141,7 @@ class FetchAPI {
       body: type === 'multipart' ? body : JSON.stringify(body),
       ...nextInit,
     })
-    const data = response.json()
-    return data
+    return this.responseHandler(response)
   }
 }
 

--- a/src/lib/fetchAPI.ts
+++ b/src/lib/fetchAPI.ts
@@ -13,7 +13,7 @@ class FetchAPI {
     }
   }
 
-  private async responseHandler(response: Response) {
+  private async handleResponse(response: Response) {
     if (!response.ok) {
       const data = await response.json()
       switch (response.status) {
@@ -71,7 +71,7 @@ class FetchAPI {
       headers: { ...this.headers, ...customHeaders },
       ...nextInit,
     })
-    return this.responseHandler(response)
+    return this.handleResponse(response)
   }
 
   public async post(
@@ -90,7 +90,7 @@ class FetchAPI {
       body: type === 'multipart' ? body : JSON.stringify(body),
       ...nextInit,
     })
-    return this.responseHandler(response)
+    return this.handleResponse(response)
   }
 
   public async put(
@@ -109,7 +109,7 @@ class FetchAPI {
       body: type === 'multipart' ? body : JSON.stringify(body),
       ...nextInit,
     })
-    return this.responseHandler(response)
+    return this.handleResponse(response)
   }
 
   public async delete(
@@ -122,7 +122,7 @@ class FetchAPI {
       headers: { ...this.headers, ...customHeaders },
       ...nextInit,
     })
-    return this.responseHandler(response)
+    return this.handleResponse(response)
   }
 
   public async patch(
@@ -141,7 +141,7 @@ class FetchAPI {
       body: type === 'multipart' ? body : JSON.stringify(body),
       ...nextInit,
     })
-    return this.responseHandler(response)
+    return this.handleResponse(response)
   }
 }
 

--- a/src/services/space/space.ts
+++ b/src/services/space/space.ts
@@ -51,8 +51,12 @@ const fetchSettingSpace = async (
 
 const fetchDeleteSpace = async (spaceId: number) => {
   const path = `/api/space/${spaceId}`
-  const response = await apiClient.delete(path)
-  return response
+  try {
+    const response = await apiClient.delete(path)
+    return response
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
 }
 
 const fetchFavoriteSpace = async ({ spaceId }: FetchGetSpaceProps) => {


### PR DESCRIPTION
## 📑 이슈 번호
Closes #191 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
### fetch error handler 추가

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### fetchAPI에 handleResponse 메서드를 추가하였습니다.
```typescript
private async handleResponse(response: Response, type?: string) {
  if (!response.ok) {
    const data = await response.json()
    switch (response.status) {
      case 401:
        notify('error', `${data.errorMessage}` || '인증되지 않은 사용자입니다.')
        break
      case 404:
        notify('error', `${data.errorMessage}` || '해당하는 요청을 찾을 수 없습니다.')
        break
      case 500:
        notify('error', `${data.errorMessage}` || '서버에 오류가 발생했습니다.')
        break
      default:
        notify('error', `${data.errorMessage}` || '알 수 없는 오류가 발생했습니다.')
        break
    }
  }
  return type === 'delete' ? response : response.json()
}
```

### 따라서 각 fetch 메서드들이 리턴하는 response를 handleResponse를 거친 후 반환했습니다.
```typescript
return this.handleResponse(response)
```

### 클라이언트 측에서 api 호출에 실패했을 때 별도의 액션을 취할 것이 아니라면 try catch문 없이 바로 호출하면 됩니다.
```typescript
// 스페이스 생성 예시
const { spaceId } = await feachCreateSpace(data, imageFile)
notify('info', '스페이스가 생성되었습니다.')
router.replace(`/space/${spaceId}`)
```

### 참고사항
- next api route에서 get을 제외한 나머지 메서드 호출에 대해서 `NextResponse.json(response)`로 리턴하는 경우에 클라이언트로 제대로 된 리턴 값을 넘겨주지 않습니다.
  - `return NextResponse.json(response)` 부분을 `return response`로 변경 해주시면 제대로 된 response를 받더라구요 참고하시면 좋을 듯 싶습니다!