### PR TITLE
알림 삭제 api 연결

### DIFF
--- a/src/app/(routes)/notification/page.tsx
+++ b/src/app/(routes)/notification/page.tsx
@@ -1,14 +1,11 @@
 'use client'
 
-import { Notification } from '@/components'
-import { mock_notificationData } from '@/data'
+import { NONE_NOTIFICATION_RESULT } from '@/components/common/NotificationList/constants'
 
 const NotificationPage = () => {
-  const notifications = mock_notificationData
-
   return (
     <div className="flex flex-col gap-2">
-      {notifications.map((notification) => (
+      {/* {notifications.map((notification) => (
         <Notification
           notificationId={notification.id}
           notificationType={notification.notificationType}
@@ -20,7 +17,10 @@ const NotificationPage = () => {
           key={notification.id}
           onClose={() => console.log('알람 닫기')}
         />
-      ))}
+      ))} */}
+      <div className="flex justify-center text-base font-semibold text-gray9">
+        {NONE_NOTIFICATION_RESULT}
+      </div>
     </div>
   )
 }

--- a/src/app/(routes)/notification/page.tsx
+++ b/src/app/(routes)/notification/page.tsx
@@ -18,7 +18,7 @@ const NotificationPage = () => {
           onClose={() => console.log('알람 닫기')}
         />
       ))} */}
-      <div className="flex justify-center text-base font-semibold text-gray9">
+      <div className="py-5 text-center text-sm font-medium text-gray9">
         {NONE_NOTIFICATION_RESULT}
       </div>
     </div>

--- a/src/app/api/notification/[notificationId]/route.ts
+++ b/src/app/api/notification/[notificationId]/route.ts
@@ -1,0 +1,25 @@
+import { useServerCookie } from '@/hooks/useServerCookie'
+import { apiServer } from '@/services/apiServices'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { notificationId: number } },
+) {
+  const { token } = useServerCookie()
+  const notificationId = params.notificationId
+  const path = `/notifications/${notificationId}`
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  }
+
+  try {
+    const data = await apiServer.delete(path, {}, headers)
+    return NextResponse.json(data)
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.message },
+      { status: error.response.status },
+    )
+  }
+}

--- a/src/components/SpaceList/SpaceList.tsx
+++ b/src/components/SpaceList/SpaceList.tsx
@@ -70,7 +70,7 @@ const SpaceList = ({
               </Fragment>
             ))
           : !isSpacesLoading && (
-              <div className="flex justify-center text-base text-gray9">
+              <div className="flex justify-center text-base font-semibold text-gray9">
                 {NONE_SEARCH_RESULT}
               </div>
             )}

--- a/src/components/SpaceList/SpaceList.tsx
+++ b/src/components/SpaceList/SpaceList.tsx
@@ -70,7 +70,7 @@ const SpaceList = ({
               </Fragment>
             ))
           : !isSpacesLoading && (
-              <div className="flex justify-center text-base font-semibold text-gray9">
+              <div className="py-5 text-center text-sm font-medium text-gray9">
                 {NONE_SEARCH_RESULT}
               </div>
             )}

--- a/src/components/common/Notification/Notification.tsx
+++ b/src/components/common/Notification/Notification.tsx
@@ -44,7 +44,7 @@ const Notification = ({
         <div>
           <span
             onClick={() => handleClickUser({ notificationId, userId, isRead })}
-            className="cursor-pointer font-bold">
+            className="cursor-pointer font-bold text-emerald6">
             {userName}
           </span>
           {NOTIFICATION_MSG.USER}
@@ -56,7 +56,7 @@ const Notification = ({
                 onClick={() =>
                   handleClickSpace({ notificationId, spaceId, isRead })
                 }
-                className="cursor-pointer font-bold">
+                className="cursor-pointer font-bold text-emerald6">
                 {spaceName}
               </span>
               {NOTIFICATION_MSG.TO}
@@ -70,7 +70,7 @@ const Notification = ({
                         isRead,
                       })
                     }
-                    className="cursor-pointer font-bold">
+                    className="cursor-pointer font-bold text-emerald6">
                     {NOTIFICATION_MSG.COMMENT}
                   </span>
                   {NOTIFICATION_MSG.COMMENT_LEAVE}

--- a/src/components/common/NotificationList/NotificationList.tsx
+++ b/src/components/common/NotificationList/NotificationList.tsx
@@ -3,10 +3,9 @@
 import { Fragment } from 'react'
 import { Spinner } from '@/components'
 import useInfiniteScroll from '@/hooks/useInfiniteScroll'
-import { fetchAccetpSpaceInvitation } from '@/services/space/spaces'
 import { InvitationsNotification, InvitationsReqBody } from '@/types'
-import { useRouter } from 'next/navigation'
 import Notification from '../Notification/Notification'
+import useAcceptNotification from './hooks/useAcceptNotification'
 import useDeleteNotification from './hooks/useDeleteNotification'
 import useNotificationQuery from './hooks/useNotificationQuery'
 
@@ -16,7 +15,6 @@ export interface NotificationListProps {
 }
 
 const NotificationList = ({ fetchFn, type }: NotificationListProps) => {
-  const router = useRouter()
   const {
     notificationList,
     fetchNextPage,
@@ -27,17 +25,7 @@ const NotificationList = ({ fetchFn, type }: NotificationListProps) => {
     type,
   })
   const { target } = useInfiniteScroll({ hasNextPage, fetchNextPage })
-
-  const handleAcceptInvite = async (notificationId: number) => {
-    try {
-      const { spaceId } = await fetchAccetpSpaceInvitation({ notificationId })
-      alert('스페이스 초대가 수락되었습니다.')
-      router.push(`/space/${spaceId}`)
-    } catch (e) {
-      alert('스페이스 초대 수락에 실패하였습니다.')
-    }
-  }
-
+  const { handleAcceptInvite } = useAcceptNotification({ type })
   const { handleDeleteNotification } = useDeleteNotification({ type })
 
   return isNotificationLoading ? (
@@ -56,7 +44,11 @@ const NotificationList = ({ fetchFn, type }: NotificationListProps) => {
                 spaceId={notification.spaceId}
                 spaceName={notification.spaceName}
                 isAccepted={notification.isAccepted}
-                onAccept={() => handleAcceptInvite(notification.notificationId)}
+                onAccept={() =>
+                  handleAcceptInvite({
+                    notificationId: notification.notificationId,
+                  })
+                }
                 onClose={() =>
                   handleDeleteNotification({
                     notificationId: notification.notificationId,

--- a/src/components/common/NotificationList/NotificationList.tsx
+++ b/src/components/common/NotificationList/NotificationList.tsx
@@ -7,6 +7,7 @@ import { fetchAccetpSpaceInvitation } from '@/services/space/spaces'
 import { InvitationsNotification, InvitationsReqBody } from '@/types'
 import { useRouter } from 'next/navigation'
 import Notification from '../Notification/Notification'
+import useDeleteNotification from './hooks/useDeleteNotification'
 import useNotificationQuery from './hooks/useNotificationQuery'
 
 export interface NotificationListProps {
@@ -37,6 +38,8 @@ const NotificationList = ({ fetchFn, type }: NotificationListProps) => {
     }
   }
 
+  const { handleDeleteNotification } = useDeleteNotification({ type })
+
   return isNotificationLoading ? (
     <Spinner />
   ) : (
@@ -54,7 +57,11 @@ const NotificationList = ({ fetchFn, type }: NotificationListProps) => {
                 spaceName={notification.spaceName}
                 isAccepted={notification.isAccepted}
                 onAccept={() => handleAcceptInvite(notification.notificationId)}
-                onClose={() => console.log('알람 닫기')}
+                onClose={() =>
+                  handleDeleteNotification({
+                    notificationId: notification.notificationId,
+                  })
+                }
                 key={notification.notificationId}
               />
             </li>

--- a/src/components/common/NotificationList/NotificationList.tsx
+++ b/src/components/common/NotificationList/NotificationList.tsx
@@ -5,6 +5,7 @@ import { Spinner } from '@/components'
 import useInfiniteScroll from '@/hooks/useInfiniteScroll'
 import { InvitationsNotification, InvitationsReqBody } from '@/types'
 import Notification from '../Notification/Notification'
+import { NONE_NOTIFICATION_RESULT } from './constants'
 import useAcceptNotification from './hooks/useAcceptNotification'
 import useDeleteNotification from './hooks/useDeleteNotification'
 import useNotificationQuery from './hooks/useNotificationQuery'
@@ -32,34 +33,40 @@ const NotificationList = ({ fetchFn, type }: NotificationListProps) => {
     <Spinner />
   ) : (
     <ul className="flex flex-col gap-y-2">
-      {notificationList?.pages.map((group, i) => (
-        <Fragment key={i}>
-          {group.responses?.map((notification: InvitationsNotification) => (
-            <li key={notification.notificationId}>
-              <Notification
-                notificationId={notification.notificationId}
-                notificationType={notification.notificationType}
-                userId={notification.invitingMemberId}
-                userName={notification.invitingMemberName}
-                spaceId={notification.spaceId}
-                spaceName={notification.spaceName}
-                isAccepted={notification.isAccepted}
-                onAccept={() =>
-                  handleAcceptInvite({
-                    notificationId: notification.notificationId,
-                  })
-                }
-                onClose={() =>
-                  handleDeleteNotification({
-                    notificationId: notification.notificationId,
-                  })
-                }
-                key={notification.notificationId}
-              />
-            </li>
-          ))}
-        </Fragment>
-      ))}
+      {notificationList?.pages[0].responses.length > 0 ? (
+        notificationList?.pages.map((group, i) => (
+          <Fragment key={i}>
+            {group.responses?.map((notification: InvitationsNotification) => (
+              <li key={notification.notificationId}>
+                <Notification
+                  notificationId={notification.notificationId}
+                  notificationType={notification.notificationType}
+                  userId={notification.invitingMemberId}
+                  userName={notification.invitingMemberName}
+                  spaceId={notification.spaceId}
+                  spaceName={notification.spaceName}
+                  isAccepted={notification.isAccepted}
+                  onAccept={() =>
+                    handleAcceptInvite({
+                      notificationId: notification.notificationId,
+                    })
+                  }
+                  onClose={() =>
+                    handleDeleteNotification({
+                      notificationId: notification.notificationId,
+                    })
+                  }
+                  key={notification.notificationId}
+                />
+              </li>
+            ))}
+          </Fragment>
+        ))
+      ) : (
+        <div className="flex justify-center text-base font-semibold text-gray9">
+          {NONE_NOTIFICATION_RESULT}
+        </div>
+      )}
       <div ref={target}></div>
     </ul>
   )

--- a/src/components/common/NotificationList/constants/index.ts
+++ b/src/components/common/NotificationList/constants/index.ts
@@ -1,0 +1,4 @@
+export const NOTIFICATION_INVITE = {
+  SUCCESS: '스페이스 초대가 수락되었습니다.',
+  ERROR: '스페이스 초대 수락에 실패하였습니다.',
+}

--- a/src/components/common/NotificationList/constants/index.ts
+++ b/src/components/common/NotificationList/constants/index.ts
@@ -2,3 +2,5 @@ export const NOTIFICATION_INVITE = {
   SUCCESS: '스페이스 초대가 수락되었습니다.',
   ERROR: '스페이스 초대 수락에 실패하였습니다.',
 }
+
+export const NONE_NOTIFICATION_RESULT = '알림이 없습니다.'

--- a/src/components/common/NotificationList/hooks/useAcceptNotification.ts
+++ b/src/components/common/NotificationList/hooks/useAcceptNotification.ts
@@ -1,0 +1,35 @@
+import { fetchAccetpSpaceInvitation } from '@/services/space/spaces'
+import { useQueryClient } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+import { notify } from '../../Toast/Toast'
+import { NOTIFICATION_INVITE } from '../constants'
+
+export interface UseAcceptNotificationProps {
+  type: 'FOLLOW' | 'COMMENT' | 'INVITATION'
+}
+
+export interface HandleAcceptInviteProps {
+  notificationId: number
+}
+
+const useAcceptNotification = ({ type }: UseAcceptNotificationProps) => {
+  const router = useRouter()
+  const queryclient = useQueryClient()
+
+  const handleAcceptInvite = async ({
+    notificationId,
+  }: HandleAcceptInviteProps) => {
+    try {
+      const { spaceId } = await fetchAccetpSpaceInvitation({ notificationId })
+      notify('success', NOTIFICATION_INVITE.SUCCESS)
+      router.push(`/space/${spaceId}`)
+      await queryclient.invalidateQueries({ queryKey: ['notification', type] })
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  return { handleAcceptInvite }
+}
+
+export default useAcceptNotification

--- a/src/components/common/NotificationList/hooks/useDeleteNotification.ts
+++ b/src/components/common/NotificationList/hooks/useDeleteNotification.ts
@@ -1,0 +1,24 @@
+import {
+  FetchDeleteNotificationProps,
+  fetchDeleteNotification,
+} from '@/services/notification'
+import { useQueryClient } from '@tanstack/react-query'
+
+export interface UseDeleteNotificationProps {
+  type: 'FOLLOW' | 'COMMENT' | 'INVITATION'
+}
+
+const useDeleteNotification = ({ type }: UseDeleteNotificationProps) => {
+  const queryclient = useQueryClient()
+
+  const handleDeleteNotification = async ({
+    notificationId,
+  }: FetchDeleteNotificationProps) => {
+    await fetchDeleteNotification({ notificationId })
+    await queryclient.invalidateQueries({ queryKey: ['notification', type] })
+  }
+
+  return { handleDeleteNotification }
+}
+
+export default useDeleteNotification

--- a/src/components/common/NotificationList/hooks/useNotificationQuery.ts
+++ b/src/components/common/NotificationList/hooks/useNotificationQuery.ts
@@ -5,7 +5,7 @@ import { useInfiniteQuery } from '@tanstack/react-query'
 const useNotificationQuery = ({ fetchFn, type }: FollowListProps) => {
   const queryKey = type
   const { data, fetchNextPage, hasNextPage, isLoading } = useInfiniteQuery({
-    queryKey: [queryKey],
+    queryKey: ['notification', queryKey],
     queryFn: ({ pageParam }) =>
       fetchFn({
         pageNumber: pageParam,

--- a/src/services/notification/index.ts
+++ b/src/services/notification/index.ts
@@ -1,0 +1,20 @@
+import { apiClient } from '../apiServices'
+
+export interface FetchDeleteNotificationProps {
+  notificationId: number
+}
+
+const fetchDeleteNotification = async ({
+  notificationId,
+}: FetchDeleteNotificationProps) => {
+  const path = `/api/notification/${notificationId}`
+
+  try {
+    const response = await apiClient.delete(path)
+    return response
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
+}
+
+export { fetchDeleteNotification }


### PR DESCRIPTION
## 📑 이슈 번호
#202 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
### 알림 삭제 api를 연결 및 구현하였습니다.
![Dec-01-2023 17-27-56](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/e598a157-c7ea-4d1a-8678-f6a2ec11fece)

<br>
<br>
<br>

### 기존에 alert로 보여주던 알림을 토스트 컴포넌트로 수정
멤버에 가입되어 있는 스페이스 알림을 수락할 시 에러 토스트가 2개가 보여져서 하나만 보이도록 수정하였습니다.

<img width="337" alt="스크린샷 2023-12-01 오후 4 38 08" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/d887b09d-504a-4117-a5c2-05cf71ffe863">
<img width="332" alt="스크린샷 2023-12-01 오후 5 23 43" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/0694322f-3b52-4ad0-ba4f-0f8d787cc6e6">



<br>
<br>
<br>

### 알림 mock data를 제거하고, 알림이 없을 시 보여주는 텍스트를 추가하였습니다.
(이후에 올라온 댓글 로그인 알림 모달 적용 pr을 보고 댓글이 없을때 나타나는 텍스트의 스타일과 동일하게 수정하였습니다.)

<img width="460" alt="스크린샷 2023-12-02 오후 4 02 55" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/c21392bc-4cf1-4de3-9749-beb9d914d24d">

<br>
<br>
<br>

### bold 처리 된 텍스트가 눈에 더 잘 보이도록 색상을 변경하였습니다.
<img width="461" alt="스크린샷 2023-12-01 오후 5 25 59" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/39c11be3-fc7e-4c68-bc73-d366b20fd23b">
<img width="456" alt="스크린샷 2023-12-01 오후 5 26 18" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/b99770e3-6bfc-41e2-aeed-09786d75edb0">


## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### 검색 결과가 없을 때 보여주는 텍스트의 CSS를 알림 페이지와 동일하게 수정하였습니다.
(이후에 올라온 댓글 로그인 알림 모달 적용 pr을 보고 댓글이 없을때 나타나는 텍스트의 스타일과 동일하게 수정하였습니다.)

<img width="461" alt="스크린샷 2023-12-02 오후 4 02 21" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/703ce246-5d7e-4207-a5f4-348ba71ae000">
