### PR TITLE
유저정보 form 버그 수정

### DIFF
--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -38,13 +38,10 @@ const Login = () => {
       </div>
       <Button
         type="button"
+        onClick={() => router.push('/kakaoLogin')}
         className="button button-md flex w-full items-center justify-center border-none bg-yellow-400 px-3 py-2.5">
         <ChatBubbleOvalLeftIcon className="h-6 w-6 text-gray-800" />
-        <div
-          onClick={() => router.push('/kakaoLogin')}
-          className="text-sm font-bold text-gray-800">
-          카카오로 시작하기
-        </div>
+        <div className="text-sm font-bold text-gray-800">카카오로 시작하기</div>
       </Button>
     </div>
   )

--- a/src/components/UserInfoForm/UserInfoForm.tsx
+++ b/src/components/UserInfoForm/UserInfoForm.tsx
@@ -8,6 +8,7 @@ import { fetchPostUserProfile } from '@/services/user/profile/profile'
 import { UserProfileResBody } from '@/types'
 import { cls } from '@/utils'
 import { CheckIcon } from '@heroicons/react/24/solid'
+import Cookies from 'js-cookie'
 import { useRouter } from 'next/navigation'
 import Button from '../common/Button/Button'
 import { CATEGORIES } from '../common/CategoryList/constants'
@@ -122,23 +123,34 @@ const UserInfoForm = ({ userData, formType }: UserInfoFormProps) => {
   const handleRegisterLinkHub = async (
     data: RegisterReqBody & EmailVerifyReqBody,
   ) => {
-    await registerLinkHub(data, imageFile)
-    notify('success', '회원가입 되었습니다.')
-    router.replace('/login')
+    try {
+      const { jwt } = await registerLinkHub(data, imageFile)
+      if (jwt) {
+        notify('success', '회원가입 되었습니다.')
+        Cookies.set('Auth-token', jwt || '')
+        router.replace('/')
+      }
+    } catch (e) {
+      notify('error', '회원가입에 실패하였습니다.')
+    }
   }
 
   const handleSettingUser = async (
     data: RegisterReqBody & EmailVerifyReqBody,
   ) => {
-    userData?.memberId &&
-      (await fetchPostUserProfile(userData?.memberId, data, imageFile))
-    notify('success', '수정되었습니다.')
-    router.back()
+    try {
+      userData?.memberId &&
+        (await fetchPostUserProfile(userData?.memberId, data, imageFile))
+      notify('success', '수정되었습니다.')
+      router.back()
+    } catch (e) {
+      notify('error', '수정에 실패했습니다.')
+    }
   }
 
   const handleWithdrawButton = () => {
     // Todo: 회원탈퇴 로직
-    notify('info', '미구현된 기능입니다.')
+    notify('info', '서비스 준비 중입니다.')
   }
 
   return (

--- a/src/components/UserInfoForm/hooks/useRegister.ts
+++ b/src/components/UserInfoForm/hooks/useRegister.ts
@@ -15,9 +15,11 @@ const useRegister = () => {
   const registerLinkHub = async (data: RegisterReqBody, imageFile?: File) => {
     data.socialId = Cookies.get('Social-Id') || ''
     data.provider = Cookies.get('Provider') || ''
-    await registerUser(data, imageFile)
+    const { jwt } = await registerUser(data, imageFile)
     Cookies.remove('Social-Id')
     Cookies.remove('Provider')
+
+    return { jwt }
   }
 
   return { registerLinkHub }

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -12,6 +12,7 @@ export interface InputProps {
   validation?: string
   disabled?: boolean
   onButtonClick?: (e?: React.MouseEvent<HTMLButtonElement>) => void
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
 }
 
 const Input = forwardRef(
@@ -27,6 +28,7 @@ const Input = forwardRef(
       validation,
       disabled,
       onButtonClick,
+      onChange,
       ...rest
     }: InputProps,
     ref?: ForwardedRef<HTMLInputElement>,
@@ -51,6 +53,7 @@ const Input = forwardRef(
             )}
             placeholder={placeholder}
             disabled={disabled}
+            onChange={onChange}
             {...rest}
           />
           {inputButton && (

--- a/src/components/common/Sidebar/hooks/useSidebar.ts
+++ b/src/components/common/Sidebar/hooks/useSidebar.ts
@@ -1,6 +1,7 @@
 import { Dispatch, SetStateAction, useState } from 'react'
 import { kakaoLogout } from '@/services/auth'
 import Cookies from 'js-cookie'
+import { notify } from '../../Toast/Toast'
 
 type SpaceType = '내 스페이스' | '즐겨찾기'
 
@@ -18,10 +19,10 @@ const useSidebar = ({ sidebarRef, setIsOpen, onClose }: useSidebarProps) => {
       await kakaoLogout()
       Cookies.remove('Auth-token')
       location.reload()
-      alert('로그아웃 되었습니다.')
+      notify('info', '로그아웃 되었습니다.')
       onClose()
     } catch (e) {
-      alert('다시 시도해 주세요.')
+      notify('error', '로그아웃에 실패하였습니다.')
     }
   }
 

--- a/src/components/common/Sidebar/hooks/useSidebar.ts
+++ b/src/components/common/Sidebar/hooks/useSidebar.ts
@@ -18,7 +18,6 @@ const useSidebar = ({ sidebarRef, setIsOpen, onClose }: useSidebarProps) => {
     try {
       await kakaoLogout()
       Cookies.remove('Auth-token')
-      location.reload()
       notify('info', '로그아웃 되었습니다.')
       onClose()
     } catch (e) {

--- a/src/lib/fetchAPI.ts
+++ b/src/lib/fetchAPI.ts
@@ -18,10 +18,7 @@ class FetchAPI {
       const data = await response.json()
       switch (response.status) {
         case 401:
-          notify(
-            'error',
-            `${data.errorMessage}` || '인증되지 않은 사용자입니다.',
-          )
+          notify('error', '인증되지 않은 사용자입니다.')
           break
         case 404:
           notify(
@@ -42,8 +39,10 @@ class FetchAPI {
           )
           break
       }
+      return data
+    } else {
+      return type === 'delete' ? response : response.json()
     }
-    return type === 'delete' ? response : response.json()
   }
 
   public static getInstance(): FetchAPI {

--- a/src/services/email/index.ts
+++ b/src/services/email/index.ts
@@ -14,8 +14,12 @@ const fetchPostEmailVerify = async (
   data: EmailVerifyReqBody & EmailReqBody,
 ) => {
   const path = '/api/email-verify'
-  const response = await apiClient.post(path, data)
-  return response
+  try {
+    const response = await apiClient.post(path, data)
+    return response
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
 }
 
 export { fetchPostEmail, fetchPostEmailVerify }


### PR DESCRIPTION
## 📑 이슈 번호
Closes #199 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
### 유저정보 form 버그를 수정하였습니다. (회원가입, 프로필 수정)

### 1. 프로필 수정을 할 때 '인증번호 전송' 버튼을 눌러야만 수정이 되던 오류를 수정하였습니다.

![userInfo1](https://github.com/Team-TenTen/LinkHub-FE/assets/66124037/ed60438e-87eb-4583-812b-ef6c7e58e9e2)

### 2. 프로필 수정 및 회원가입에서 인증번호 전송 버튼을 눌렀을 때 인증번호 입력 인풋이 보이지 않던 오류를 수정하였습니다.

![userInfo2](https://github.com/Team-TenTen/LinkHub-FE/assets/66124037/31eddb3f-f0c4-44ba-a527-3fa417cb1433)

### 3. 프로필 수정 및 회원가입에서 올바르지 않은 이메일양식으로 인증번호 전송 버튼을 눌렀을 때 가입하기 버튼이 활성화 되고 폼 제출이 진행되던 오류를 수정하였습니다.
- 알림 토스트의 영문 에러 메세지는 서버에서 반환해주는 에러메세지를 한글로 변경해달라고 요청드렸습니다.

![userInfo3](https://github.com/Team-TenTen/LinkHub-FE/assets/66124037/ba5b43b6-2ac1-4118-b1e8-55df27803fa9)

### 4. 파일 이미지 확장자를 .jpg, .png, .svg로 제한하였습니다.

### 5. 회원가입할 때 카테고리 디폴트값을 없앴습니다.
```typescript
const {
  register,
  getValues,
  setValue,
  handleSubmit,
  formState: { errors },
} = useForm<RegisterReqBody & EmailVerifyReqBody>({
  defaultValues: {
    nickname: userData?.nickname || '',
    aboutMe: userData?.aboutMe || '',
    newsEmail: userData?.newsEmail || '',
    favoriteCategory: userData?.favoriteCategory || '',  // 회원가입시에 디폴트값은 빈 값
    isSubscribed: userData?.isSubscribed || false,
  },
})
```

### 6. 회원가입시 로그인된 상태로 메인페이지로 이동하게 변경하였습니다.

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### fetchAPI의 handleResponse 메서드를 수정하였습니다.
```typescript
private async handleResponse(response: Response, type?: string) {
  if (!response.ok) {
    const data = await response.json()
    switch (response.status) {
      case 401:
        notify('error', `${data.errorMessage}` || '인증되지 않은 사용자입니다.')
        break
      case 404:
        notify('error', `${data.errorMessage}` || '해당하는 요청을 찾을 수 없습니다.')
        break
      case 500:
        notify('error', `${data.errorMessage}` || '서버에 오류가 발생했습니다.')
        break
      default:
        notify('error', `${data.errorMessage}` || '알 수 없는 오류가 발생했습니다.')
        break
    }
    return data  // 에러케이스의 경우에도 response를 리턴해주어야하는 상황이 있어 리턴값 추가
  }
  return type === 'delete' ? response : response.json()
}
```

### 그 외 변경 사항
- 기존의 로그아웃 시 나타나던 브라우저 알림창을 토스트 알림으로 변경하였습니다. ([a62c179](https://github.com/Team-TenTen/LinkHub-FE/pull/206/commits/a62c17992abf5137e8bd7995b4603c321b403ba5))
- 로그인 버튼 클릭 영역을 수정하였습니다. ([b8737a6](https://github.com/Team-TenTen/LinkHub-FE/pull/206/commits/b8737a62d52b1d64da9b28a4703357f939fb7add))
