### PR TITLE
링크 수정 폼 validation 오류 수정

### DIFF
--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -9,7 +9,10 @@ import { XMarkIcon } from '@heroicons/react/20/solid'
 import Chip from '../common/Chip/Chip'
 import { COLORS } from '../common/Chip/constants'
 import { CreateLinkFormValue } from '../common/LinkList/LinkList'
-import { LINK_FORM_VALIDATION } from '../common/LinkList/constants'
+import {
+  LINK_FORM_PLACEHOLDER,
+  LINK_FORM_VALIDATION,
+} from '../common/LinkList/constants'
 import { Tag } from '../common/Space/hooks/useGetTags'
 import useTagInput from './hooks/useTagInput'
 
@@ -65,7 +68,7 @@ const TagInput = ({
           <input
             className="w-full py-0.5 text-sm font-medium text-gray9 placeholder-gray4 outline-none"
             type={selectedTag && 'hidden'}
-            placeholder="태그를 입력해 주세요. (0 ~ 10글자)"
+            placeholder={LINK_FORM_PLACEHOLDER.TAG}
             {...register('tagName', {
               maxLength: {
                 value: 10,

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -44,10 +44,11 @@ const Input = forwardRef(
             type={type}
             className={cls(
               'rounded-md border bg-bgColor px-3 py-2.5 text-sm font-medium text-gray9 placeholder-gray4 outline-none disabled:border-gray3 disabled:text-gray3 disabled:placeholder-gray3',
-              inputButton &&
-                (buttonColor === 'green'
+              inputButton
+                ? buttonColor === 'green'
                   ? 'border-emerald6 pr-20'
-                  : 'border-slate5 pr-20'),
+                  : 'border-slate5 pr-20'
+                : 'border-slate5',
             )}
             placeholder={placeholder}
             disabled={disabled}

--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -228,6 +228,7 @@ const LinkItem = ({
                 </Button>
                 <Button
                   onClick={() => {
+                    setIsUrlCheck(true)
                     handleOpenCurrentModal('update')
                   }}>
                   <PencilSquareIcon className="h-6 w-6 p-0.5 text-slate6" />

--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'react-hook-form'
 import TagInput from '@/components/TagInput/TagInput'
 import { useModal } from '@/hooks'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
-import { cls } from '@/utils'
 import {
   DocumentTextIcon,
   HeartIcon as HeartIconOutline,
@@ -186,7 +185,7 @@ const LinkItem = ({
           </div>
         </div>
       ) : (
-        <div className="flex min-h-[101.5px] flex-col justify-between gap-1 rounded-md border px-3 py-2.5">
+        <div className="flex min-h-[101.5px] flex-col justify-between gap-1 rounded-md border border-slate3 px-3 py-2.5">
           <Link
             onClick={() => isMember && handleSaveReadInfo({ spaceId, linkId })}
             className="cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap text-sm font-medium text-gray9"

--- a/src/components/common/LinkList/LinkList.tsx
+++ b/src/components/common/LinkList/LinkList.tsx
@@ -18,6 +18,7 @@ import {
   LINK_FORM_PLACEHOLDER,
   LINK_FORM_VALIDATION,
   MORE_TEXT,
+  NONE_LINK_RESULT,
 } from './constants'
 import useCreateLink from './hooks/useCreateLink'
 import useGetMeta from './hooks/useGetMeta'
@@ -114,7 +115,7 @@ const LinkList = ({
     sort,
     tagId,
   })
-
+  console.log(links?.pages[0].responses.length)
   return isLinksLoading ? (
     <Spinner />
   ) : (
@@ -127,7 +128,7 @@ const LinkList = ({
         {isCanEdit && (
           <button
             className={cls(
-              'flex bg-slate-100 px-3 py-2.5 text-sm font-medium text-gray9 dark:bg-slate-800',
+              'flex border-slate3 bg-slate-100 px-3 py-2.5 text-sm font-medium text-gray9 dark:bg-slate-800',
               type === 'list'
                 ? 'border-t border-slate3'
                 : 'min-h-[101.5px] items-center justify-center rounded-md border',
@@ -140,28 +141,38 @@ const LinkList = ({
           </button>
         )}
         <>
-          {links?.pages.map((group) =>
-            group.responses.map((link: Link) => (
-              <LinkItem
-                spaceId={spaceId}
-                linkId={link.linkId}
-                title={link.title}
-                url={link.url}
-                tagName={link.tagName}
-                tagColor={link.tagColor}
-                readUsers={link.linkViewHistories}
-                isInitLiked={link.isLiked}
-                likeInitCount={link.likeCount}
-                read={read}
-                summary={summary}
-                edit={edit}
-                isMember={isMember}
-                type={type}
-                tags={tags}
-                refetchTags={refetchTags}
-                key={link.linkId}
-              />
-            )),
+          {links?.pages[0].responses.length ? (
+            links?.pages.map((group) =>
+              group.responses.map((link: Link) => (
+                <LinkItem
+                  spaceId={spaceId}
+                  linkId={link.linkId}
+                  title={link.title}
+                  url={link.url}
+                  tagName={link.tagName}
+                  tagColor={link.tagColor}
+                  readUsers={link.linkViewHistories}
+                  isInitLiked={link.isLiked}
+                  likeInitCount={link.likeCount}
+                  read={read}
+                  summary={summary}
+                  edit={edit}
+                  isMember={isMember}
+                  type={type}
+                  tags={tags}
+                  refetchTags={refetchTags}
+                  key={link.linkId}
+                />
+              )),
+            )
+          ) : type === 'list' ? (
+            <div className="mt-14 flex justify-center text-sm text-gray9">
+              {NONE_LINK_RESULT}
+            </div>
+          ) : (
+            <div className="flex items-center justify-center rounded-md border border-slate3">
+              <div className="flex text-sm text-gray9">{NONE_LINK_RESULT}</div>
+            </div>
           )}
         </>
       </div>

--- a/src/components/common/LinkList/constants/index.ts
+++ b/src/components/common/LinkList/constants/index.ts
@@ -21,3 +21,5 @@ export const LINK_FORM_VALIDATION = {
   TITLE_LENGTH: '제목은 2자 이상 50자 이하로 작성해야 합니다.',
   TAG_LENGTH: '태그는 10자 이하로 작성해야 합니다.',
 }
+
+export const NONE_LINK_RESULT = '링크가 없습니다.'

--- a/src/components/common/LinkList/constants/index.ts
+++ b/src/components/common/LinkList/constants/index.ts
@@ -10,8 +10,8 @@ export const LINK_FORM = {
 
 export const LINK_FORM_PLACEHOLDER = {
   URL: 'URL을 입력해 주세요.',
-  TITLE: '제목을 입력해 주세요. (2 ~ 50글자)',
-  TAG: '태그를 입력해 주세요. (0 ~ 10글자)',
+  TITLE: '제목을 입력해 주세요.',
+  TAG: '태그를 입력해 주세요.',
 }
 
 export const LINK_FORM_VALIDATION = {

--- a/src/components/common/LinkList/constants/index.ts
+++ b/src/components/common/LinkList/constants/index.ts
@@ -18,6 +18,6 @@ export const LINK_FORM_VALIDATION = {
   INCORRECT_URL: '올바르지 않은 URL입니다.',
   URL_NOT_BUTTTON: 'URL 입력 후 확인 버튼을 눌러주세요.',
   NONE_TITLE: '제목을 입력해 주세요.',
-  TITLE_LENGTH: '제목은 2글자 이상 50글자 이하로 작성해야 합니다.',
-  TAG_LENGTH: '태그는 10글자 이하로 작성해야 합니다.',
+  TITLE_LENGTH: '제목은 2자 이상 50자 이하로 작성해야 합니다.',
+  TAG_LENGTH: '태그는 10자 이하로 작성해야 합니다.',
 }


### PR DESCRIPTION
## 📑 이슈 번호
#209 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
### 카드 형식의 링크를 수정하려고 하면 링크 URL을 다시 등록해야 하는 문제를 수정하였습니다.
![Dec-01-2023 19-10-15](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/5af9aaef-7bac-4c00-8f0d-e1b6e812ffb9)

<br>
<br>

### 링크 생성, 수정 폼의 placeholder, validation 텍스트를 수정하였습니다.
<img width="422" alt="스크린샷 2023-12-01 오후 7 13 29" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/285f352e-297e-416a-ad44-c129a13c15a4">

<img width="420" alt="스크린샷 2023-12-01 오후 7 15 18" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/ff7d8e50-10d9-4cd0-a8a2-fcb37a6a5218">

<br>
<br>

### 링크가 존재하지 않을 때의 텍스트를 추가하였습니다.
<img width="461" alt="스크린샷 2023-12-01 오후 7 49 57" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/52fb84aa-bd13-46c1-8eee-368d61a6c69b">

<img width="456" alt="스크린샷 2023-12-01 오후 7 50 30" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/6439f57c-1a51-4cb8-a1f4-09256192f948">


## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
- Input 컴포넌트의 테두리 색상이 제대로 적용되지 않는 문제를 발견하여 수정하였습니다.
- 링크가 카드 형식일 때 테두리를 slate3 색상으로 적용하였습니다.
