### PR TITLE
스페이스 입력 폼 오류 수정

### DIFF
--- a/src/app/(routes)/space/[spaceId]/page.tsx
+++ b/src/app/(routes)/space/[spaceId]/page.tsx
@@ -51,6 +51,7 @@ const SpacePage = ({ params }: { params: { spaceId: number } }) => {
           scrap={space.scrapCount}
           favorite={space.favoriteCount}
           hasFavorite={space.hasFavorite}
+          hasScrap={space.hasScrap}
         />
       )}
       {tabList.length > MIN_TAB_NUMBER && (

--- a/src/components/CommentList/CommentList.tsx
+++ b/src/components/CommentList/CommentList.tsx
@@ -33,7 +33,7 @@ const CommentList = ({
     <ul className="flex flex-col gap-y-2 pt-2">
       {comments?.pages.map((group, groupIdx) => (
         <Fragment key={groupIdx}>
-          {group.responses.map((comment: CommentResBody) => (
+          {group.responses?.map((comment: CommentResBody) => (
             <li key={comment.commentId}>
               <Comment
                 spaceId={spaceId}

--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -90,6 +90,7 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
           type="file"
           ref={selectSpaceImage}
           onChange={handleFileChange}
+          accept=".jpg, .png, .svg"
           hidden
         />
         <div onClick={() => selectSpaceImage?.current?.click()}>

--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -46,7 +46,7 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
     defaultValues: {
       spaceName: space?.spaceName || '',
       description: space?.description || '',
-      category: space?.category || 'ENTER_ART',
+      category: space?.category || '',
       isVisible: space?.isVisible || false,
       isComment: space?.isComment || false,
       isLinkSummarizable: space?.isLinkSummarizable || false,

--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -208,8 +208,8 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
           </div>
           <div className="flex items-center justify-between border-t border-slate3 p-3">
             <div className="text-sm font-medium text-gray9 opacity-50">
-              링크 3줄 요약 여부
-              <span className="ml-2">(서비스 준비중입니다)</span>
+              {/* 링크 3줄 요약 여부 */}
+              <span>서비스 준비 중입니다.</span>
             </div>
             <Toggle
               {...register('isLinkSummarizable')}

--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -3,6 +3,7 @@
 import { ChangeEvent, useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { CategoryList, Input, Toggle } from '@/components'
+import { MIN_TAB_NUMBER } from '@/constants'
 import {
   feachCreateSpace,
   fetchScrapSpace,
@@ -13,6 +14,9 @@ import Image from 'next/image'
 import { usePathname, useRouter } from 'next/navigation'
 import Button from '../common/Button/Button'
 import { CATEGORIES } from '../common/CategoryList/constants'
+import Tab from '../common/Tab/Tab'
+import TabItem from '../common/Tab/TabItem'
+import useTab from '../common/Tab/hooks/useTab'
 import { notify } from '../common/Toast/Toast'
 import { SPACE_FORM_CONSTNAT } from './constant'
 
@@ -25,6 +29,7 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
   const selectSpaceImage = useRef<HTMLInputElement | null>(null)
   const [thumnail, setThumnail] = useState(space?.spaceImagePath)
   const [imageFile, setImageFile] = useState<File>()
+  const { currentTab, tabList } = useTab({ type: 'space', space })
   const path = usePathname()
   const spaceId = Number(path.split('/')[2])
   const router = useRouter()
@@ -109,6 +114,18 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
           )}
         </div>
       </div>
+      {tabList.length > MIN_TAB_NUMBER && (
+        <Tab>
+          {tabList.map((tabItem) => (
+            <TabItem
+              active={currentTab === tabItem.content}
+              text={tabItem.text}
+              dest={tabItem.dest}
+              key={tabItem.content}
+            />
+          ))}
+        </Tab>
+      )}
       <div className="flex flex-col gap-3 pl-4 pr-4">
         <div>
           <Input

--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -14,6 +14,7 @@ import Image from 'next/image'
 import { usePathname, useRouter } from 'next/navigation'
 import Button from '../common/Button/Button'
 import { CATEGORIES } from '../common/CategoryList/constants'
+import useGetSpace from '../common/Space/hooks/useGetSpace'
 import Tab from '../common/Tab/Tab'
 import TabItem from '../common/Tab/TabItem'
 import useTab from '../common/Tab/hooks/useTab'
@@ -33,6 +34,7 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
   const path = usePathname()
   const spaceId = Number(path.split('/')[2])
   const router = useRouter()
+  const getSpace = useGetSpace()
 
   const {
     register,
@@ -70,7 +72,7 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
 
   return (
     <form
-      className="flex flex-col gap-3"
+      className="flex flex-col"
       onSubmit={handleSubmit(async (data) => {
         if (spaceType === 'Create') {
           const { spaceId } = await feachCreateSpace(data, imageFile)
@@ -114,7 +116,7 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
           )}
         </div>
       </div>
-      {tabList.length > MIN_TAB_NUMBER && (
+      {spaceType === 'Setting' && tabList.length > MIN_TAB_NUMBER && (
         <Tab>
           {tabList.map((tabItem) => (
             <TabItem
@@ -126,7 +128,17 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
           ))}
         </Tab>
       )}
-      <div className="flex flex-col gap-3 pl-4 pr-4">
+      <div className="mt-3 flex flex-col gap-3 pl-4 pr-4">
+        {spaceType === 'Scrap' && (
+          <div className="flex items-center justify-start rounded-md border border-slate3 bg-emerald05 p-3">
+            <div className="text-sm font-medium text-gray9">
+              <span className="font-semibold">
+                @{getSpace.space?.spaceName}{' '}
+              </span>
+              에서 가져오는 중
+            </div>
+          </div>
+        )}
         <div>
           <Input
             {...register('spaceName', {

--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -207,16 +207,16 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
             />
           </div>
           <div className="flex items-center justify-between border-t border-slate3 p-3">
-            <div className="text-sm font-medium text-gray9">
+            <div className="text-sm font-medium text-gray9 opacity-50">
               링크 3줄 요약 여부
+              <span className="ml-2">(서비스 준비중입니다)</span>
             </div>
             <Toggle
               {...register('isLinkSummarizable')}
               on={space?.isLinkSummarizable}
               name="isLinkSummarizable"
-              onChange={() =>
-                setValue('isLinkSummarizable', !getValues('isLinkSummarizable'))
-              }
+              isDisabled={true}
+              onChange={() => {}}
             />
           </div>
           <div className="flex items-center justify-between border-b border-t border-slate3 p-3">

--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -73,9 +73,9 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
           router.replace(`/space/${spaceId}`)
         } else if (spaceType === 'Setting') {
           try {
-            await fetchSettingSpace(spaceId, data, imageFile)
+            const response = await fetchSettingSpace(spaceId, data, imageFile)
             notify('info', '스페이스를 수정했습니다.')
-            router.back()
+            router.push(`/space/${response.spaceId}`)
           } catch (e) {
             router.replace('/')
           }

--- a/src/components/common/Space/Space.tsx
+++ b/src/components/common/Space/Space.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/navigation'
 import Button from '../Button/Button'
 import Chip from '../Chip/Chip'
 import LoginModal from '../Modal/LoginModal'
+import { notify } from '../Toast/Toast'
 import { SPACE_CONSTANT } from './constants'
 import useFavorites from './hooks/useFavorites'
 
@@ -25,6 +26,7 @@ interface SpaceProps {
   scrap: number
   favorite: number
   hasFavorite?: boolean
+  hasScrap?: boolean
 }
 
 const Space = ({
@@ -38,6 +40,7 @@ const Space = ({
   scrap,
   favorite,
   hasFavorite,
+  hasScrap,
 }: SpaceProps) => {
   const router = useRouter()
   const { isLoggedIn } = useCurrentUser()
@@ -50,7 +53,11 @@ const Space = ({
   const { Modal, isOpen, modalOpen, modalClose } = useModal()
 
   const handleClickScrapButton = async () => {
-    router.push(`/space/${spaceId}/scrap`)
+    if (!hasScrap) {
+      router.push(`/space/${spaceId}/scrap`)
+    } else {
+      notify('error', '스페이스는 한 번만 가져갈 수 있습니다.')
+    }
   }
 
   return (
@@ -105,7 +112,9 @@ const Space = ({
           <div className="flex justify-end gap-2">
             <Button
               className="button button-round button-white"
-              onClick={handleClickScrapButton}>
+              onClick={() => {
+                isLoggedIn ? handleClickScrapButton() : modalOpen()
+              }}>
               <InboxArrowDownIcon className="h-4 w-4" />
               {SPACE_CONSTANT.SCRAP} {scrap}
             </Button>

--- a/src/components/common/Space/Space.tsx
+++ b/src/components/common/Space/Space.tsx
@@ -115,7 +115,11 @@ const Space = ({
               onClick={() => {
                 isLoggedIn ? handleClickScrapButton() : modalOpen()
               }}>
-              <InboxArrowDownIcon className="h-4 w-4" />
+              {hasScrap ? (
+                <InboxArrowDownIcon className="h-4 w-4 text-yellow-300" />
+              ) : (
+                <InboxArrowDownIcon className="h-4 w-4" />
+              )}
               {SPACE_CONSTANT.SCRAP} {scrap}
             </Button>
             <Button

--- a/src/components/common/Space/hooks/useGetSpace.ts
+++ b/src/components/common/Space/hooks/useGetSpace.ts
@@ -23,7 +23,7 @@ const useGetSpace = (): {
 
   const handleGetSpace = useCallback(async () => {
     setIsLoading(true)
-    const data = await fetchGetSpace({ spaceId })
+    const data = spaceId && (await fetchGetSpace({ spaceId }))
     setSpace(data)
     setIsLoading(false)
   }, [spaceId, setIsLoading])

--- a/src/components/common/Toggle/Toggle.tsx
+++ b/src/components/common/Toggle/Toggle.tsx
@@ -6,11 +6,12 @@ export interface ToggleProps {
   name: string
   on?: boolean
   onChange: (e?: React.ChangeEvent<HTMLInputElement>) => void
+  isDisabled?: boolean
 }
 
 const Toggle = forwardRef(
   (
-    { name, on = false, onChange }: ToggleProps,
+    { name, on = false, onChange, isDisabled }: ToggleProps,
     ref?: ForwardedRef<HTMLInputElement>,
   ) => {
     const [checked, toggle] = useToggle(on)
@@ -28,6 +29,7 @@ const Toggle = forwardRef(
           className="appearance-none"
           name={name}
           onChange={handleChange}
+          disabled={isDisabled}
         />
         <div
           className={cls(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,6 +82,7 @@ export interface RegisterReqBody {
 
 // 스페이스 상세 res body
 export interface SpaceDetailResBody {
+  hasScrap: boolean | undefined
   spaceId: number
   spaceName: string
   description: string


### PR DESCRIPTION
## 📑 이슈 번호
Closes #207 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
### 스페이스 입력 폼 오류를 수정하였습니다.

### 1. 댓글이 존재하는 스페이스의 댓글 작성 여부를 비활성화하면 에러화면이 뜨는 오류를 수정하였습니다.
![spaceForm1](https://github.com/Team-TenTen/LinkHub-FE/assets/66124037/78be8da1-6b20-47da-9b8b-ab21abab14a8)

### 2. 로그인하지 않은 사용자가 스페이스 가져가기 버튼을 눌렀을 때 스페이스 생성 페이지로 이동하던 오류를 수정하였습니다.
![spaceForm2](https://github.com/Team-TenTen/LinkHub-FE/assets/66124037/ecf171f9-c86b-4659-bd96-112ffc22a7bb)

### 3. 한 번 가져오기를 한 스페이스의 가져오기 버튼을 누르면 스페이스 생성 페이지로 이동하던 오류를 수정하였습니다.
![spaceForm3](https://github.com/Team-TenTen/LinkHub-FE/assets/66124037/adb1d75c-2c9d-4162-861c-3f20e0231e0b)

### 4. 스페이스 이미지의 확장자를 .jpg, .png, .svg로 제한하였습니다.

### 5. 스페이스 세팅 페이지에 스페이스 탭이 추가되었습니다.
![spaceForm5](https://github.com/Team-TenTen/LinkHub-FE/assets/66124037/5c63b0fd-39d9-4df7-be13-86e946528863)

### 6. 스페이스를 가져올 때 어떤 스페이스에서 가져오는지 확인할 수 있게 추가하였습니다.
![spaceForm6](https://github.com/Team-TenTen/LinkHub-FE/assets/66124037/0c5c7056-d5bc-4e65-9e21-58668eab3688)

### 7. 가져온 스페이스의 스페이스 가져오기 버튼을 즐겨찾기 버튼과 같이 색상으로 표시해주었습니다.

### 8. 스페이스 설정의 링크 3줄 요약 여부에 '서비스 준비중입니다' 문구와 함께 비활성화 조치를 취하였습니다. 

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
