### PR TITLE
링크 수정 버그 수정

### DIFF
--- a/src/components/TagInput/TagInput.tsx
+++ b/src/components/TagInput/TagInput.tsx
@@ -75,7 +75,11 @@ const TagInput = ({
                 updateFilteredTags(e.target.value)
               },
               onBlur: (e) => {
-                if (e.target.value.trim()) findExistingTag(e.target.value)
+                const value = e.target.value.trim()
+                if (value) {
+                  findExistingTag(value)
+                }
+                setValue('tagName', value)
                 setIsFocused(false)
               },
             })}

--- a/src/services/link/link.ts
+++ b/src/services/link/link.ts
@@ -67,7 +67,14 @@ const fetchUpdateLink = async ({
   color,
 }: FetchUpdateLinkProps) => {
   const path = `/api/space/${spaceId}/links`
-  const body = { spaceId, linkId, url, title, tagName, color }
+  const body = {
+    spaceId,
+    linkId,
+    url,
+    title,
+    ...(tagName && { tagName }),
+    ...(color && { color }),
+  }
 
   try {
     const response = await apiClient.put(path, body)


### PR DESCRIPTION
## 📑 이슈 번호
- close #204 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 링크 수정 시 태그를 삭제하면 발생하는 버그를 수정했습니다.
  - tagName, color가 없으면 body에 포함하지 않고 요청을 보내야 해서 fetch 함수를 수정했습니다.
  - tagName은 `" "`을 허용하지 않기 때문에 trim()으로 입력 값의 앞뒤 공백을 제거했습니다.

https://github.com/Team-TenTen/LinkHub-FE/assets/49032882/34e16573-865e-4b0d-9310-1ec53e5f83c7


## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
