### PR TITLE
헤더 알림 뱃지 구현

### DIFF
--- a/src/app/api/notification/unchecked/route.ts
+++ b/src/app/api/notification/unchecked/route.ts
@@ -1,0 +1,21 @@
+import { useServerCookie } from '@/hooks/useServerCookie'
+import { apiServer } from '@/services/apiServices'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const { token } = useServerCookie()
+  const path = '/notifications/unchecked'
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  }
+
+  try {
+    const data = await apiServer.get(path, {}, headers)
+    return NextResponse.json(data)
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.response.data.message },
+      { status: error.response.status },
+    )
+  }
+}

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -2,7 +2,7 @@
 
 import { LinkIcon } from '@heroicons/react/20/solid'
 import { BellIcon } from '@heroicons/react/24/outline'
-import { MagnifyingGlassCircleIcon } from '@heroicons/react/24/outline'
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 import { Bars3Icon } from '@heroicons/react/24/solid'
 import Link from 'next/link'
 import Button from '../Button/Button'
@@ -42,7 +42,7 @@ const Header = () => {
           <Button
             className="flex h-8 w-8 items-center justify-center"
             onClick={openSearchModal}>
-            <MagnifyingGlassCircleIcon className="h-6 w-6 text-slate9" />
+            <MagnifyingGlassIcon className="h-6 w-6 text-slate9" />
           </Button>
           <Button
             className="flex h-8 w-8 items-center justify-center"

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,53 +1,24 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
 import { LinkIcon } from '@heroicons/react/20/solid'
 import { BellIcon } from '@heroicons/react/24/outline'
 import { MagnifyingGlassCircleIcon } from '@heroicons/react/24/outline'
 import { Bars3Icon } from '@heroicons/react/24/solid'
 import Link from 'next/link'
-import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import Button from '../Button/Button'
 import SearchModal from '../SearchModal/SearchModal'
 import Sidebar from '../Sidebar/Sidebar'
+import useHeader from './hooks/useHeader'
 
 const Header = () => {
-  const pathname = usePathname()
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false)
-  const isSearchModalOpen = searchParams.get('search')
-  const currentPage = pathname
-    .split(/[^a-zA-Z]/)[1] // 라우터명
-    .replace(/^[a-z]/, (char) => char.toUpperCase()) // 첫글자 대문자 치환
-
-  const createQueryString = useCallback(
-    (name: string, value: string) => {
-      const params = new URLSearchParams(searchParams)
-      params.set(name, value)
-
-      return params.toString()
-    },
-    [searchParams],
-  )
-
-  const deleteQueryString = useCallback(
-    (name: string) => {
-      const params = new URLSearchParams(searchParams)
-      params.delete(name)
-
-      return params.toString()
-    },
-    [searchParams],
-  )
-
-  useEffect(() => {
-    if (isSidebarOpen || isSearchModalOpen) {
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = 'auto'
-    }
-  }, [isSidebarOpen, isSearchModalOpen])
+  const {
+    currentPage,
+    isSidebarOpen,
+    isSearchModalOpen,
+    openSearchModal,
+    closeSearchModal,
+    setIsSidebarOpen,
+  } = useHeader()
 
   return (
     <>
@@ -70,12 +41,7 @@ const Header = () => {
           </Button>
           <Button
             className="flex h-8 w-8 items-center justify-center"
-            onClick={() =>
-              router.replace(
-                pathname + '?' + createQueryString('search', 'true'),
-                { scroll: false },
-              )
-            }>
+            onClick={openSearchModal}>
             <MagnifyingGlassCircleIcon className="h-6 w-6 text-slate9" />
           </Button>
           <Button
@@ -91,15 +57,7 @@ const Header = () => {
           onClose={() => setIsSidebarOpen(false)}
         />
       )}
-      {isSearchModalOpen && (
-        <SearchModal
-          onClose={() =>
-            router.replace(pathname + '?' + deleteQueryString('search'), {
-              scroll: false,
-            })
-          }
-        />
-      )}
+      {isSearchModalOpen && <SearchModal onClose={closeSearchModal} />}
     </>
   )
 }

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { cls } from '@/utils'
 import { LinkIcon } from '@heroicons/react/20/solid'
 import { BellIcon } from '@heroicons/react/24/outline'
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
@@ -13,6 +14,7 @@ import useHeader from './hooks/useHeader'
 const Header = () => {
   const {
     currentPage,
+    notificationCount,
     isSidebarOpen,
     isSearchModalOpen,
     openSearchModal,
@@ -34,11 +36,20 @@ const Header = () => {
           {currentPage || 'Home'}
         </div>
         <div className="flex items-center justify-center gap-x-1">
-          <Button className="flex h-8 w-8 items-center justify-center">
-            <Link href="/notification/invite">
-              <BellIcon className="h-6 w-6 text-slate9" />
-            </Link>
-          </Button>
+          <Link
+            href="/notification/invite"
+            className="relative flex h-8 w-8 items-center justify-center">
+            <BellIcon className="h-6 w-6 text-slate9" />
+            {notificationCount > 0 && (
+              <span
+                className={cls(
+                  'absolute top-0 rounded-full bg-emerald-500 px-1 text-xs text-white',
+                  notificationCount > 9 ? 'right-[-7px]' : 'right-0',
+                )}>
+                {notificationCount > 9 ? '9+' : notificationCount}
+              </span>
+            )}
+          </Link>
           <Button
             className="flex h-8 w-8 items-center justify-center"
             onClick={openSearchModal}>

--- a/src/components/common/Header/hooks/useHeader.ts
+++ b/src/components/common/Header/hooks/useHeader.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+
+const useHeader = () => {
+  const pathname = usePathname()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false)
+  const isSearchModalOpen = searchParams.get('search')
+  const currentPage = pathname
+    .split(/[^a-zA-Z]/)[1] // 라우터명
+    .replace(/^[a-z]/, (char) => char.toUpperCase()) // 첫글자 대문자 치환
+
+  const createQueryString = useCallback(
+    (name: string, value: string) => {
+      const params = new URLSearchParams(searchParams)
+      params.set(name, value)
+
+      return params.toString()
+    },
+    [searchParams],
+  )
+
+  const deleteQueryString = useCallback(
+    (name: string) => {
+      const params = new URLSearchParams(searchParams)
+      params.delete(name)
+
+      return params.toString()
+    },
+    [searchParams],
+  )
+
+  const openSearchModal = () => {
+    router.replace(pathname + '?' + createQueryString('search', 'true'), {
+      scroll: false,
+    })
+  }
+
+  const closeSearchModal = () => {
+    router.replace(pathname + '?' + deleteQueryString('search'), {
+      scroll: false,
+    })
+  }
+
+  useEffect(() => {
+    if (isSidebarOpen || isSearchModalOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'auto'
+    }
+  }, [isSidebarOpen, isSearchModalOpen])
+
+  return {
+    currentPage,
+    isSidebarOpen,
+    isSearchModalOpen,
+    openSearchModal,
+    closeSearchModal,
+    setIsSidebarOpen,
+  }
+}
+
+export default useHeader

--- a/src/components/common/Header/hooks/useHeader.ts
+++ b/src/components/common/Header/hooks/useHeader.ts
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
+import { fetchGetUnCheckedNotifications } from '@/services/notification/invitations'
+import { useQuery } from '@tanstack/react-query'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
 const useHeader = () => {
@@ -10,6 +12,10 @@ const useHeader = () => {
   const currentPage = pathname
     .split(/[^a-zA-Z]/)[1] // 라우터명
     .replace(/^[a-z]/, (char) => char.toUpperCase()) // 첫글자 대문자 치환
+  const { data } = useQuery({
+    queryKey: ['notificationCount'],
+    queryFn: () => fetchGetUnCheckedNotifications(),
+  })
 
   const createQueryString = useCallback(
     (name: string, value: string) => {
@@ -53,6 +59,7 @@ const useHeader = () => {
 
   return {
     currentPage,
+    notificationCount: data?.unCheckedNotificationCount,
     isSidebarOpen,
     isSearchModalOpen,
     openSearchModal,

--- a/src/services/notification/invitations.ts
+++ b/src/services/notification/invitations.ts
@@ -1,6 +1,17 @@
 import { InvitationsReqBody } from '@/types'
 import { apiClient } from '../apiServices'
 
+const fetchGetUnCheckedNotifications = async () => {
+  const path = '/api/notification/unchecked'
+
+  try {
+    const response = await apiClient.get(path)
+    return response
+  } catch (e) {
+    if (e instanceof Error) throw new Error(e.message)
+  }
+}
+
 const fetchGetInvitations = async ({
   pageNumber,
   pageSize,
@@ -20,4 +31,4 @@ const fetchGetInvitations = async ({
   }
 }
 
-export { fetchGetInvitations }
+export { fetchGetUnCheckedNotifications, fetchGetInvitations }


### PR DESCRIPTION
## 📑 이슈 번호
- close #220 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 헤더 알림 뱃지를 구현했습니다.
  - 9개 초과 시 `9+`로 표시됩니다.
  - 카운트를 보여주면 좋을 것 같아 아래와 같이 구현했습니다. 다른 의견 있으면 남겨주세요!
- 검색 아이콘을 수정했습니다.

<img width="360" alt="LinkHub-FE_header-notification-badge_01" src="https://github.com/Team-TenTen/LinkHub-FE/assets/49032882/8d56e353-5aa4-4035-b7ba-88e128a1cdd8">
<img width="360" alt="LinkHub-FE_header-notification-badge_02" src="https://github.com/Team-TenTen/LinkHub-FE/assets/49032882/47e16344-f791-4484-a168-bc057705aa0f">

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### Header 컴포넌트
- 로직 관련된 코드를 useHeader 커스텀 훅으로 분리했습니다.