### PR TITLE
인기 링크 리스트 슬라이드 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-hook-form": "^7.47.0",
         "react-spinners": "^0.13.8",
         "react-toastify": "^9.1.3",
+        "swiper": "^11.0.5",
         "tailwind-scrollbar-hide": "^1.1.7"
       },
       "devDependencies": {
@@ -5314,6 +5315,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.0.5.tgz",
+      "integrity": "sha512-rhCwupqSyRnWrtNzWzemnBLMoyYuoDgGgspAm/8iBD3jCvAWycPLH4Z3TB0O5520DHLzMx94yUMH/B9Efpa48w==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwind-scrollbar-hide": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.47.0",
-    "react-toastify": "^9.1.3",
     "react-spinners": "^0.13.8",
+    "react-toastify": "^9.1.3",
+    "swiper": "^11.0.5",
     "tailwind-scrollbar-hide": "^1.1.7"
   },
   "devDependencies": {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,11 @@ import { useCategoryParam, useSortParam } from '@/hooks'
 import useGetPopularLinks from '@/hooks/useGetPopularLinks'
 import { fetchGetSpaces } from '@/services/space/spaces'
 import { PopularLinkResBody } from '@/types'
+import 'swiper/css'
+import 'swiper/css/free-mode'
+import 'swiper/css/pagination'
+import { FreeMode } from 'swiper/modules'
+import { Swiper, SwiperSlide } from 'swiper/react'
 
 export default function Home() {
   const { links, isPopularLinksLoading } = useGetPopularLinks()
@@ -25,21 +30,34 @@ export default function Home() {
         <Spinner />
       ) : (
         <>
-          <section className="px-4 pb-10">
+          <section className="px-4 pb-8">
             <h2 className="py-4 font-bold text-gray9">인기있는 링크</h2>
-            {links &&
-              links.map((link: PopularLinkResBody) => (
-                <LinkItem
-                  linkId={link.linkId}
-                  title={link.title}
-                  url={link.url}
-                  tagName={link.tagName}
-                  tagColor={link.tagColor as ChipColors}
-                  isInitLiked={link.isLiked}
-                  likeInitCount={link.likeCount}
-                  key={link.linkId}
-                />
-              ))}
+            {links && (
+              <Swiper
+                slidesPerView={2.1}
+                spaceBetween={16}
+                freeMode={true}
+                pagination={{
+                  clickable: true,
+                }}
+                modules={[FreeMode]}
+                className="mySwiper">
+                {links.map((link: PopularLinkResBody) => (
+                  <SwiperSlide key={link.linkId}>
+                    <LinkItem
+                      linkId={link.linkId}
+                      title={link.title}
+                      url={link.url}
+                      tagName={link.tagName}
+                      tagColor={link.tagColor as ChipColors}
+                      isInitLiked={link.isLiked}
+                      likeInitCount={link.likeCount}
+                      type="card"
+                    />
+                  </SwiperSlide>
+                ))}
+              </Swiper>
+            )}
           </section>
           <section>
             <div className="sticky top-[53px] z-40 bg-bgColor">


### PR DESCRIPTION
## 📑 이슈 번호
#226 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
### 인기 링크 리스트를 카드 형식으로 변경하였고, 슬라이드를 적용하였습니다. (Swiper 사용)

![Dec-02-2023 07-37-36](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/1d502bc3-c889-41dc-b1bd-f081faf8cac6)

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### 인기있는 링크 리스트의 bottom padding을 pb-10에서 pb-8로 수정하였습니다.

<br>

### 추가 사항
인기 링크 리스트를 슬라이드로 변경하고 보니까 5개는 슬라이드 치고 너무 적은 것 같아서 10개를 가져오는 것은 어떨까요?
더이상 화면 제약도 받지 않아서 저는 늘려도 좋을 것 같다는 생각이 드네요!