### PR TITLE
스페이스 입력 폼 오류 수정

### DIFF
--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -156,7 +156,7 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
                 message: '스페이스명은 20글자 이하여야 합니다.',
               },
               pattern: {
-                value: /^\S+$/,
+                value: /^\S+(\s*\S*\s*)*\S+$/,
                 message: '스페이스명은 공백으로 시작하거나 끝날 수 없습니다.',
               },
             })}

--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -155,6 +155,10 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
                 value: 20,
                 message: '스페이스명은 20글자 이하여야 합니다.',
               },
+              pattern: {
+                value: /^\S+$/,
+                message: '스페이스명은 공백으로 시작하거나 끝날 수 없습니다.',
+              },
             })}
             label="스페이스 이름"
             placeholder="스페이스 이름을 입력하세요"

--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -81,6 +81,10 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
         } else if (spaceType === 'Setting') {
           try {
             const response = await fetchSettingSpace(spaceId, data, imageFile)
+            if (!response.spaceId) {
+              router.replace('/')
+              return
+            }
             notify('info', '스페이스를 수정했습니다.')
             router.push(`/space/${response.spaceId}`)
           } catch (e) {

--- a/src/components/Space/SpaceForm.tsx
+++ b/src/components/Space/SpaceForm.tsx
@@ -173,7 +173,7 @@ const SpaceForm = ({ spaceType, space }: SpaceFormProps) => {
           />
         </div>
         <div className="flex flex-col gap-2">
-          <div className="text-sm font-semibold text-gray9">관심 카테고리</div>
+          <div className="text-sm font-semibold text-gray9">카테고리</div>
           <div>
             <CategoryList
               type="default"


### PR DESCRIPTION
## 📑 이슈 번호
Closes #238 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
### 스페이스 입력 폼 오류 수정 

### 1. 스페이스 입력 폼의 '관심 카테고리' 타이틀을 '카테고리'로 수정하였습니다.

### 2. 타인의 스페이스 수정페이지를 url로 접근하였을 때 수정 버튼을 누르면 수정되지않고 메인화면으로 이동하게 수정하였습니다.
- 타인의 스페이스 수정페이지 접근 자체를 막고싶은데 쉽지가 않네요

### 3. 스페이스명의 시작과 끝에 공백문자가 포함되지 못하도록 수정하였습니다.
## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
