### PR TITLE
알림 삭제 기능 수정

### DIFF
--- a/src/app/(routes)/notification/page.tsx
+++ b/src/app/(routes)/notification/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { NONE_NOTIFICATION_RESULT } from '@/components/common/NotificationList/constants'
+import { SEACH_MODAL_INFO } from '@/components/common/SearchModal/constants'
 
 const NotificationPage = () => {
   return (
@@ -19,7 +20,7 @@ const NotificationPage = () => {
         />
       ))} */}
       <div className="py-5 text-center text-sm font-medium text-gray9">
-        {NONE_NOTIFICATION_RESULT}
+        {SEACH_MODAL_INFO}
       </div>
     </div>
   )

--- a/src/components/common/NotificationList/NotificationList.tsx
+++ b/src/components/common/NotificationList/NotificationList.tsx
@@ -63,7 +63,7 @@ const NotificationList = ({ fetchFn, type }: NotificationListProps) => {
           </Fragment>
         ))
       ) : (
-        <div className="flex justify-center text-base font-semibold text-gray9">
+        <div className="py-5 text-center text-sm font-medium text-gray9">
           {NONE_NOTIFICATION_RESULT}
         </div>
       )}

--- a/src/components/common/NotificationList/hooks/useAcceptNotification.ts
+++ b/src/components/common/NotificationList/hooks/useAcceptNotification.ts
@@ -24,6 +24,9 @@ const useAcceptNotification = ({ type }: UseAcceptNotificationProps) => {
       notify('success', NOTIFICATION_INVITE.SUCCESS)
       router.push(`/space/${spaceId}`)
       await queryclient.invalidateQueries({ queryKey: ['notification', type] })
+      await queryclient.invalidateQueries({
+        queryKey: ['notificationCount'],
+      })
     } catch (e) {
       console.error(e)
     }

--- a/src/components/common/NotificationList/hooks/useDeleteNotification.ts
+++ b/src/components/common/NotificationList/hooks/useDeleteNotification.ts
@@ -16,6 +16,7 @@ const useDeleteNotification = ({ type }: UseDeleteNotificationProps) => {
   }: FetchDeleteNotificationProps) => {
     await fetchDeleteNotification({ notificationId })
     await queryclient.invalidateQueries({ queryKey: ['notification', type] })
+    await queryclient.invalidateQueries({ queryKey: ['notificationCount'] })
   }
 
   return { handleDeleteNotification }


### PR DESCRIPTION
## 📑 이슈 번호
#246 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 알림 삭제 시 카운트가 즉시 반영되도록 수정하였습니다.
- 스페이스 초대 수락 시 카운트가 즉시 반영되도록 수정하였습니다.
- 알림 페이지에서 알림이 없을 때 나타나는 텍스트를 "서비스 준비 중입니다." 로 변경하였습니다.
- 초대 페이지에서 알림이 없을 때 나타나는 텍스트의 스타일을 수정하였습니다.

![Dec-03-2023 14-00-26](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/b5913d4e-284e-4ae6-b2f5-c027975fd3f5)

<img width="492" alt="스크린샷 2023-12-03 오후 2 06 40" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/6e26b868-e371-4dea-840a-1d73cc6bdbff">

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
