### PR TITLE
Avatar 컴포넌트 이미지 크기 오류 수정

### DIFF
--- a/src/components/common/Avatar/Avatar.tsx
+++ b/src/components/common/Avatar/Avatar.tsx
@@ -12,13 +12,14 @@ export interface AvatarProps {
 }
 
 const Avatar = ({ src, width, height, alt, className }: AvatarProps) => {
+  const avatarStyle = `relative h-[${width}px] w-[${height}px]`
+
   return (
-    <div className="inline-block">
+    <div className={avatarStyle}>
       <Image
         src={src}
-        width={width}
-        height={height}
         alt={alt}
+        layout="fill"
         className={cls(
           className,
           'rounded-full border border-slate3 object-cover',

--- a/src/components/common/Sidebar/Sidebar.tsx
+++ b/src/components/common/Sidebar/Sidebar.tsx
@@ -66,12 +66,14 @@ const Sidebar = ({ isSidebarOpen, onClose }: SidebarProps) => {
             ) : (
               <>
                 <div className="flex items-center px-2">
-                  <Avatar
-                    src={currentUser.profileImagePath}
-                    width={40}
-                    height={40}
-                    alt={currentUser.nickname}
-                  />
+                  <div>
+                    <Avatar
+                      src={currentUser.profileImagePath}
+                      width={40}
+                      height={40}
+                      alt={currentUser.nickname}
+                    />
+                  </div>
                   <p className="font-sm ml-3 w-full overflow-hidden text-ellipsis	whitespace-nowrap font-medium text-gray9">
                     {currentUser.nickname}
                   </p>


### PR DESCRIPTION
## 📑 이슈 번호
#252 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
프로필 페이지, 멤버 리스트, 사이드바에서 이미지 크기가 비정상적으로 나오는 문제를 수정하였습니다.
<img width="498" alt="스크린샷 2023-12-03 오후 4 30 25" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/087d95e1-e1b5-4578-a0d7-6c8b8bacb1c4">
<img width="482" alt="스크린샷 2023-12-03 오후 4 30 36" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/f8637a45-e346-4d18-bd90-d2b357a7e04d">
<img width="294" alt="스크린샷 2023-12-03 오후 4 30 44" src="https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/e58ad9a2-b4b6-4d09-b0c6-7ff92b049aef">

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
사이드바 프로필 이미지 상위 요소에 div 태그를 추가하였습니다.
```tsx
<div>
    <Avatar
      src={currentUser.profileImagePath}
      width={40}
      height={40}
      alt={currentUser.nickname}
    />
</div>
```