### PR TITLE
유저 정보 입력 폼 오류 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,8 +34,8 @@ export default function RootLayout({
                 <Header />
                 <main className="pt-[53px]">{children}</main>
               </div>
+              <ToastContainer />
             </Providers>
-            <ToastContainer />
           </body>
         </AuthProvider>
       </TanstackQueryContext>

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -17,10 +17,10 @@ const Login = () => {
       router.replace('/')
     } else if (searchParams.get('socialId')) {
       Cookies.set('Social-Id', searchParams.get('socialId') || '', {
-        expires: 1 / 144,
+        expires: 1 / 288,
       })
       Cookies.set('Provider', searchParams.get('provider') || '', {
-        expires: 1 / 144,
+        expires: 1 / 288,
       })
       router.replace('/register')
     }

--- a/src/components/UserInfoForm/UserInfoForm.tsx
+++ b/src/components/UserInfoForm/UserInfoForm.tsx
@@ -254,7 +254,9 @@ const UserInfoForm = ({ userData, formType }: UserInfoFormProps) => {
         </div>
       )}
       <div className="flex flex-col">
-        <div className="py-2 text-sm font-semibold text-gray9">카테고리</div>
+        <div className="py-2 text-sm font-semibold text-gray9">
+          관심 카테고리
+        </div>
         <CategoryList
           type="default"
           horizontal={false}

--- a/src/components/UserInfoForm/UserInfoForm.tsx
+++ b/src/components/UserInfoForm/UserInfoForm.tsx
@@ -254,9 +254,7 @@ const UserInfoForm = ({ userData, formType }: UserInfoFormProps) => {
         </div>
       )}
       <div className="flex flex-col">
-        <div className="py-2 text-sm font-semibold text-gray9">
-          관심 카테고리
-        </div>
+        <div className="py-2 text-sm font-semibold text-gray9">카테고리</div>
         <CategoryList
           type="default"
           horizontal={false}

--- a/src/components/UserInfoForm/hooks/useRegister.ts
+++ b/src/components/UserInfoForm/hooks/useRegister.ts
@@ -1,5 +1,7 @@
+import { notify } from '@/components/common/Toast/Toast'
 import { registerUser } from '@/services/auth'
 import Cookies from 'js-cookie'
+import { useRouter } from 'next/navigation'
 
 export interface RegisterReqBody {
   socialId: string
@@ -12,14 +14,20 @@ export interface RegisterReqBody {
 }
 
 const useRegister = () => {
+  const router = useRouter()
   const registerLinkHub = async (data: RegisterReqBody, imageFile?: File) => {
-    data.socialId = Cookies.get('Social-Id') || ''
-    data.provider = Cookies.get('Provider') || ''
-    const { jwt } = await registerUser(data, imageFile)
-    Cookies.remove('Social-Id')
-    Cookies.remove('Provider')
+    if (Cookies.get('Social-Id') && Cookies.get('Provider')) {
+      data.socialId = Cookies.get('Social-Id') || ''
+      data.provider = Cookies.get('Provider') || ''
+      const { jwt } = await registerUser(data, imageFile)
+      Cookies.remove('Social-Id')
+      Cookies.remove('Provider')
 
-    return { jwt }
+      return { jwt }
+    } else {
+      router.replace('/login')
+      notify('warning', '5분이 지나 세션이 만료되었습니다. 다시 시도해주세요.')
+    }
   }
 
   return { registerLinkHub }


### PR DESCRIPTION
## 📑 이슈 번호
Closes #237 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
### 유저 정보 입력 폼 오류를 수정했습니다.

### 1. 유저 프로필 default image를 변경하였습니다.

### 2. 잘못된 인증번호를 입력할 경우에 입력 폼 제출 버튼이 활성화 되던 문제를 수정하고 토스트 알림이 뜨도록 변경했습니다.

### 3. 카카오 provider와 socialId가 만료된 후에 회원가입을 진행하면 세션만료라는 토스트알림과 함께 로그인페이지로 이동하게 수정하였습니다.
- 카카오 provider와 socialId의 만료기한의 10분에서 5분으로 변경하였습니다.
## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
