### PR TITLE
CategoryList 컴포넌트 슬라이드 적용

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -123,3 +123,11 @@
   max-width: 436px;
   max-height: 25%;
 }
+
+.category-swiper {
+  padding: 16px !important;
+}
+
+.category-swiper .swiper-slide {
+  width: auto;
+}

--- a/src/components/common/CategoryList/CategoryList.tsx
+++ b/src/components/common/CategoryList/CategoryList.tsx
@@ -1,6 +1,10 @@
 'use client'
 
-import { cls } from '@/utils'
+import 'swiper/css'
+import 'swiper/css/free-mode'
+import 'swiper/css/pagination'
+import { FreeMode } from 'swiper/modules'
+import { Swiper, SwiperSlide } from 'swiper/react'
 import CategoryListItem from './CategoryListItem'
 import { CATEGORIES } from './constants'
 import useCategoryList from './hooks/useCategoryList'
@@ -25,20 +29,30 @@ const CategoryList = ({
     onChange,
   })
 
-  return (
-    <ul
-      className={cls(
-        'flex w-full gap-1.5',
-        horizontal
-          ? 'horizontal-scroll snap-x scroll-px-4 overflow-x-auto scroll-smooth py-4'
-          : 'flex-wrap',
-      )}>
+  return horizontal ? (
+    <Swiper
+      direction="horizontal"
+      slidesPerView="auto"
+      spaceBetween={6}
+      freeMode={true}
+      modules={[FreeMode]}
+      className="category-swiper">
+      {categoryKeys.map((category, i) => (
+        <SwiperSlide key={i}>
+          <CategoryListItem
+            label={category}
+            value={categoryValues[i]}
+            active={index === i}
+            as="link"
+          />
+        </SwiperSlide>
+      ))}
+    </Swiper>
+  ) : (
+    <ul className="flex w-full flex-wrap gap-1.5">
       {categoryKeys.map((category, i) => (
         <li
-          className={cls(
-            'shrink-0',
-            horizontal && 'snap-end first:pl-4 last:pr-4',
-          )}
+          className="shrink-0"
           key={category}>
           <CategoryListItem
             label={category}

--- a/src/components/common/CategoryList/CategoryListItem.tsx
+++ b/src/components/common/CategoryList/CategoryListItem.tsx
@@ -1,10 +1,12 @@
 import { cls } from '@/utils'
+import Link from 'next/link'
 
 export interface CategoryListItemProps {
   label: string
   value?: string
   active: boolean
   disabled?: boolean
+  as?: string
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
 }
 
@@ -13,9 +15,23 @@ const CategoryListItem = ({
   value,
   active = false,
   disabled,
+  as,
   onClick,
 }: CategoryListItemProps) => {
-  return (
+  return as === 'link' ? (
+    <Link
+      href={{
+        query: { category: value },
+      }}
+      className={cls(
+        'inline-block rounded-3xl border px-4 py-2 text-sm font-medium',
+        active
+          ? 'border-slate-700 bg-slate5 text-white dark:border-slate-400'
+          : 'border-slate3 text-slate6',
+      )}>
+      {label}
+    </Link>
+  ) : (
     <button
       type="button"
       value={value}

--- a/src/components/common/Sidebar/Sidebar.tsx
+++ b/src/components/common/Sidebar/Sidebar.tsx
@@ -4,7 +4,13 @@ import { useRef, useState } from 'react'
 import { Spinner } from '@/components'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { cls } from '@/utils'
+import { PlusIcon } from '@heroicons/react/20/solid'
+import { UserIcon } from '@heroicons/react/24/outline'
 import { XMarkIcon } from '@heroicons/react/24/outline'
+import {
+  ArchiveBoxIcon as ArchiveBoxOutlineIcon,
+  StarIcon as StarOutlineIcon,
+} from '@heroicons/react/24/outline'
 import { ArchiveBoxIcon, StarIcon } from '@heroicons/react/24/solid'
 import Link from 'next/link'
 import Avatar from '../Avatar/Avatar'
@@ -81,13 +87,20 @@ const Sidebar = ({ isSidebarOpen, onClose }: SidebarProps) => {
                 </div>
                 <Link
                   href={`/user/${currentUser.memberId}`}
-                  className="my-2 px-2 py-2 text-base font-bold text-gray9"
+                  className="mb-2 mt-4 flex items-center px-2 py-2 text-base font-bold text-gray9"
                   onClick={onClose}>
-                  프로필
+                  <UserIcon className="mr-1.5 h-5 w-5" />내 프로필
                 </Link>
                 <div className="border-y border-slate3 px-2">
                   <div className="mt-2 flex justify-between py-2 text-base font-bold text-gray9">
-                    {spaceType}
+                    <div className="flex items-center">
+                      {spaceType === '내 스페이스' ? (
+                        <ArchiveBoxOutlineIcon className="mr-1.5 h-5 w-5" />
+                      ) : (
+                        <StarOutlineIcon className="mr-1.5 h-5 w-5" />
+                      )}
+                      {spaceType}
+                    </div>
                     {spaceType === '내 스페이스' ? (
                       <Button
                         className="button button-round button-white"
@@ -104,16 +117,13 @@ const Sidebar = ({ isSidebarOpen, onClose }: SidebarProps) => {
                       </Button>
                     )}
                   </div>
-
                   <ul>
                     {spaces &&
                       Object.values(spaces).map(({ spaceId, spaceName }) => (
-                        <li
-                          className="border-b border-slate3 last:border-none"
-                          key={spaceId}>
+                        <li key={spaceId}>
                           <Link
                             href={`/space/${spaceId}`}
-                            className="block px-3 py-2.5 text-sm text-gray9"
+                            className="block px-3 py-1.5 text-sm text-gray9 hover:underline"
                             onClick={onClose}>
                             {spaceName}
                           </Link>
@@ -129,8 +139,9 @@ const Sidebar = ({ isSidebarOpen, onClose }: SidebarProps) => {
                 </div>
                 <Link
                   href="/space/create"
-                  className="my-2 px-2 py-2 text-base font-bold text-gray9"
+                  className="my-2 flex items-center px-2 py-2 text-base font-bold text-gray9"
                   onClick={onClose}>
+                  <PlusIcon className="mr-1.5 h-5 w-5" />
                   스페이스 생성
                 </Link>
               </>


### PR DESCRIPTION
## 📑 이슈 번호
- close #249 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 카테고리 리스트 컴포넌트가 horizotal인 경우 슬라이드를 적용했습니다.

https://github.com/Team-TenTen/LinkHub-FE/assets/49032882/9edb2434-acd6-4512-9e4e-823827e6c233


## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
- Sidebar 컴포넌트 각 메뉴에 아이콘 추가했습니다.
<img width="360" alt="LinkHub-FE_categorylist-slide_02" src="https://github.com/Team-TenTen/LinkHub-FE/assets/49032882/b3a6589a-cde4-45ab-a143-62c2fdbfdd73">
