### PR TITLE
open-graph-scraper 예외 추가

### DIFF
--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -101,8 +101,14 @@ const LinkItem = ({
     handleChangeUrl,
     handleGetMeta,
   } = useGetMeta({ getValues, setValue, modalClose })
-  const { handleUpdateLink } = useUpdateLink({ spaceId, linkId, refetchTags })
-  const { handleDeleteLink } = useDeleteLink({ refetchTags })
+  const { isUpdateLinkLoading, handleUpdateLink } = useUpdateLink({
+    spaceId,
+    linkId,
+    refetchTags,
+  })
+  const { isDeleteLinkLoading, handleDeleteLink } = useDeleteLink({
+    refetchTags,
+  })
   const { handleSaveReadInfo } = useReadSaveLink()
   const { isLiked, likeCount, handleClickLike } = useLikeLink({
     spaceId,
@@ -367,7 +373,9 @@ const LinkItem = ({
               {DELETE_TEXT}
             </div>
           )}
-          {isMetaLoading && <Spinner />}
+          {(isMetaLoading || isUpdateLinkLoading || isDeleteLinkLoading) && (
+            <Spinner />
+          )}
         </Modal>
       )}
       {currentModal === 'login' && (

--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -27,6 +27,7 @@ import useGetMeta from '../LinkList/hooks/useGetMeta'
 import LoginModal from '../Modal/LoginModal'
 import NoneServiceModal from '../Modal/NoneServiceModal'
 import { RefetchTagsType, Tag } from '../Space/hooks/useGetTags'
+import Spinner from '../Spinner/Spinner'
 import { DELETE_TEXT } from './\bconstants'
 import useDeleteLink from './hooks/useDeleteLink'
 import useLikeLink from './hooks/useLikeLink'
@@ -95,6 +96,7 @@ const LinkItem = ({
     setUrlErrorText,
     isShowFormError,
     setIsShowFormError,
+    isMetaLoading,
     handleModalClose,
     handleChangeUrl,
     handleGetMeta,
@@ -365,6 +367,7 @@ const LinkItem = ({
               {DELETE_TEXT}
             </div>
           )}
+          {isMetaLoading && <Spinner />}
         </Modal>
       )}
       {currentModal === 'login' && (

--- a/src/components/common/LinkItem/hooks/useDeleteLink.ts
+++ b/src/components/common/LinkItem/hooks/useDeleteLink.ts
@@ -15,6 +15,8 @@ const useDeleteLink = ({ refetchTags }: UseDeleteLinkProps) => {
     spaceId,
     linkId,
   }: FetchDeleteLinkProps) => {
+    if (isDeleteLinkLoading) return
+
     setIsDeleteLinkLoading(true)
     await fetchDeleteLink({ spaceId, linkId })
     await queryClient.invalidateQueries({ queryKey: ['links', spaceId] })

--- a/src/components/common/LinkItem/hooks/useDeleteLink.ts
+++ b/src/components/common/LinkItem/hooks/useDeleteLink.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { FetchDeleteLinkProps, fetchDeleteLink } from '@/services/link/link'
 import { useQueryClient } from '@tanstack/react-query'
 import { RefetchTagsType } from '../../Space/hooks/useGetTags'
@@ -8,17 +9,20 @@ export interface UseDeleteLinkProps {
 
 const useDeleteLink = ({ refetchTags }: UseDeleteLinkProps) => {
   const queryClient = useQueryClient()
+  const [isDeleteLinkLoading, setIsDeleteLinkLoading] = useState(false)
 
   const handleDeleteLink = async ({
     spaceId,
     linkId,
   }: FetchDeleteLinkProps) => {
+    setIsDeleteLinkLoading(true)
     await fetchDeleteLink({ spaceId, linkId })
     await queryClient.invalidateQueries({ queryKey: ['links', spaceId] })
     refetchTags?.()
+    setIsDeleteLinkLoading(false)
   }
 
-  return { handleDeleteLink }
+  return { isDeleteLinkLoading, handleDeleteLink }
 }
 
 export default useDeleteLink

--- a/src/components/common/LinkItem/hooks/useUpdateLink.ts
+++ b/src/components/common/LinkItem/hooks/useUpdateLink.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { fetchUpdateLink } from '@/services/link/link'
 import { useQueryClient } from '@tanstack/react-query'
 import { RefetchTagsType } from '../../Space/hooks/useGetTags'
@@ -21,12 +22,14 @@ const useUpdateLink = ({
   refetchTags,
 }: UseUpdateLinkProps) => {
   const queryClient = useQueryClient()
+  const [isUpdateLinkLoading, setIsUpdateLinkLoading] = useState(false)
   const handleUpdateLink = async ({
     url,
     title,
     tagName,
     color = 'emerald',
   }: HandleUpdateLinkProps) => {
+    setIsUpdateLinkLoading(true)
     await fetchUpdateLink({
       spaceId,
       linkId,
@@ -37,9 +40,10 @@ const useUpdateLink = ({
     })
     await queryClient.invalidateQueries({ queryKey: ['links', spaceId] })
     refetchTags?.()
+    setIsUpdateLinkLoading(false)
   }
 
-  return { handleUpdateLink }
+  return { isUpdateLinkLoading, handleUpdateLink }
 }
 
 export default useUpdateLink

--- a/src/components/common/LinkItem/hooks/useUpdateLink.ts
+++ b/src/components/common/LinkItem/hooks/useUpdateLink.ts
@@ -29,6 +29,8 @@ const useUpdateLink = ({
     tagName,
     color = 'emerald',
   }: HandleUpdateLinkProps) => {
+    if (isUpdateLinkLoading) return
+
     setIsUpdateLinkLoading(true)
     await fetchUpdateLink({
       spaceId,

--- a/src/components/common/LinkList/LinkList.tsx
+++ b/src/components/common/LinkList/LinkList.tsx
@@ -79,7 +79,7 @@ const LinkList = ({
   refetchTags,
 }: LinkListProps) => {
   const { Modal, isOpen, modalOpen, modalClose } = useModal()
-  const { handleCreateLink } = useCreateLink({
+  const { isCreateLinkLoading, handleCreateLink } = useCreateLink({
     spaceId,
     refetchTags,
   })
@@ -259,7 +259,7 @@ const LinkList = ({
               validation={errors.tagName?.message}
             />
           </div>
-          {isMetaLoading && <Spinner />}
+          {(isMetaLoading || isCreateLinkLoading) && <Spinner />}
         </Modal>
       )}
     </>

--- a/src/components/common/LinkList/LinkList.tsx
+++ b/src/components/common/LinkList/LinkList.tsx
@@ -105,6 +105,7 @@ const LinkList = ({
     setUrlErrorText,
     isShowFormError,
     setIsShowFormError,
+    isMetaLoading,
     handleModalClose,
     handleChangeUrl,
     handleGetMeta,
@@ -258,6 +259,7 @@ const LinkList = ({
               validation={errors.tagName?.message}
             />
           </div>
+          {isMetaLoading && <Spinner />}
         </Modal>
       )}
     </>

--- a/src/components/common/LinkList/hooks/useCreateLink.ts
+++ b/src/components/common/LinkList/hooks/useCreateLink.ts
@@ -33,6 +33,8 @@ const useCreateLink = ({
     tagName,
     color,
   }: FetchCreateLinkProps) => {
+    if (isCreateLinkLoading) return
+
     setIsCreateLinkLoading(true)
     await fetchCreateLink({
       spaceId,

--- a/src/components/common/LinkList/hooks/useCreateLink.ts
+++ b/src/components/common/LinkList/hooks/useCreateLink.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { FetchCreateLinkProps, fetchCreateLink } from '@/services/link/link'
 import { fetchGetTags } from '@/services/space/space'
 import { useQueryClient } from '@tanstack/react-query'
@@ -10,6 +11,7 @@ export interface UseCreateLinkProps {
   refetchTags?: RefetchTagsType
 }
 export interface UseCreateLinkReturnType {
+  isCreateLinkLoading: boolean
   handleCreateLink: ({
     url,
     title,
@@ -23,6 +25,7 @@ const useCreateLink = ({
   refetchTags,
 }: UseCreateLinkProps): UseCreateLinkReturnType => {
   const queryclient = useQueryClient()
+  const [isCreateLinkLoading, setIsCreateLinkLoading] = useState(false)
 
   const handleCreateLink = async ({
     url,
@@ -30,6 +33,7 @@ const useCreateLink = ({
     tagName,
     color,
   }: FetchCreateLinkProps) => {
+    setIsCreateLinkLoading(true)
     await fetchCreateLink({
       spaceId,
       url,
@@ -43,9 +47,11 @@ const useCreateLink = ({
     })
     await queryclient.invalidateQueries({ queryKey: ['links', spaceId] })
     refetchTags?.()
+    setIsCreateLinkLoading(false)
   }
 
   return {
+    isCreateLinkLoading,
     handleCreateLink,
   }
 }

--- a/src/components/common/LinkList/hooks/useGetMeta.ts
+++ b/src/components/common/LinkList/hooks/useGetMeta.ts
@@ -14,6 +14,7 @@ const useGetMeta = ({ getValues, setValue, modalClose }: UseGetMetaProps) => {
   const [isUrlCheck, setIsUrlCheck] = useState(false)
   const [urlErrorText, setUrlErrorText] = useState('')
   const [isShowFormError, setIsShowFormError] = useState(false)
+  const [isMetaLoading, setIsMetaLoading] = useState(false)
 
   const getIsValidUrl = () => {
     const url = getValues('url')
@@ -28,9 +29,7 @@ const useGetMeta = ({ getValues, setValue, modalClose }: UseGetMetaProps) => {
     data: string
     error: boolean
   }) => {
-    if (data) {
-      setValue('title', data)
-    }
+    setValue('title', data)
 
     if (error) {
       setUrlErrorText(LINK_FORM_VALIDATION.INCORRECT_URL)
@@ -43,10 +42,12 @@ const useGetMeta = ({ getValues, setValue, modalClose }: UseGetMetaProps) => {
 
   const handleGetMeta = async ({ url }: FetchGetMetaProps) => {
     if (getIsValidUrl()) {
+      setIsMetaLoading(true)
       const { data, error } = await fetchGetMeta({
         url,
       })
       handleUrlValidation({ data, error })
+      setIsMetaLoading(false)
     } else {
       setUrlErrorText(LINK_FORM_VALIDATION.URL_INVALID_FORM)
     }
@@ -77,6 +78,7 @@ const useGetMeta = ({ getValues, setValue, modalClose }: UseGetMetaProps) => {
     setUrlErrorText,
     isShowFormError,
     setIsShowFormError,
+    isMetaLoading,
     getIsValidUrl,
     handleModalClose,
     handleChangeUrl,

--- a/src/components/common/LinkList/hooks/useGetMeta.ts
+++ b/src/components/common/LinkList/hooks/useGetMeta.ts
@@ -41,6 +41,8 @@ const useGetMeta = ({ getValues, setValue, modalClose }: UseGetMetaProps) => {
   }
 
   const handleGetMeta = async ({ url }: FetchGetMetaProps) => {
+    if (isMetaLoading) return
+
     if (getIsValidUrl()) {
       setIsMetaLoading(true)
       const { data, error } = await fetchGetMeta({


### PR DESCRIPTION
## 📑 이슈 번호
#276 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
### 메타 데이터를 가져오는 api 함수를 수정하였습니다.
네이버 블로그와 같은 iframe으로 이루어진 사이트는 메타 데이터를 가져오지 못하는 문제를 해결하였습니다.

### 링크 생성, 수정 폼 validation을 변경하였습니다.
`https://` `http://` `file://` 프로토콜 형식은 지키면서
존재하지 않는 url을 입력 시에도 title 인풋의 disabled를 false로 변경하였습니다. (대신 제목에 아무것도 들어가지 않음)

### 중복 호출 방지
링크 생성 버튼을 빠르게 클릭 시 링크가 중복해서 생성되는 문제가 발생해서
링크 생성, 수정, 삭제, 메타 데이터 가져오는 버튼을 api 호출 중일 때 중복 클릭할 수 없도록 구현하였습니다.

### 로딩 스피너 추가
메타 데이터를 가져올 때와 링크 생성, 수정, 삭제 시 로딩 스피너를 추가하였습니다.

![Dec-05-2023 04-21-37](https://github.com/Team-TenTen/LinkHub-FE/assets/39931980/ae5d3950-0a1c-4549-832e-4973af42b272)


## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
