### PR TITLE
스페이스 필터 조회 로직 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,9 @@
 'use client'
 
-import {
-  CategoryList,
-  Dropdown,
-  LinkItem,
-  SpaceList,
-  Spinner,
-} from '@/components'
+import { CategoryList, Dropdown, LinkItem, Spinner } from '@/components'
 import FloatingButton from '@/components/FloatingButton/FloatingButton'
 import { ChipColors } from '@/components/common/Chip/Chip'
+import MainSpaceList from '@/components/common/MainSpaceList/MainSpaceList'
 import { useCategoryParam, useSortParam } from '@/hooks'
 import useGetPopularLinks from '@/hooks/useGetPopularLinks'
 import { fetchGetSpaces } from '@/services/space/spaces'
@@ -77,7 +72,7 @@ export default function Home() {
                 onChange={handleCategoryChange}
               />
             </div>
-            <SpaceList
+            <MainSpaceList
               queryKey="main"
               sort={sort ?? ''}
               category={category ?? ''}

--- a/src/components/SpaceList/hooks/useMainSpacesQuery.ts
+++ b/src/components/SpaceList/hooks/useMainSpacesQuery.ts
@@ -1,0 +1,77 @@
+import { PAGE_SIZE } from '@/constants'
+import { SpaceResBody } from '@/types'
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { SpaceListProps } from '../SpaceList'
+
+interface MainSpacePageType {
+  metaData?: {
+    hasNext: boolean
+    lastId: number
+    lastFavoriteCount: number
+  }
+  responses: SpaceResBody[]
+}
+
+const useMainSpacesQuery = ({
+  queryKey,
+  memberId,
+  sort,
+  category,
+  keyword,
+  fetchFn,
+}: SpaceListProps) => {
+  const sortValue =
+    queryKey === 'main' || queryKey === 'search'
+      ? sort === 'favorite'
+        ? 'favorite_count'
+        : 'created_at'
+      : undefined
+  const categoryValue = category === 'all' ? '' : category.toUpperCase()
+  const { data, fetchNextPage, hasNextPage, isLoading } = useInfiniteQuery({
+    queryKey: [
+      'spaces',
+      queryKey,
+      {
+        ...(memberId && { memberId: memberId }),
+        ...(sortValue && { sort: sortValue }),
+        category: categoryValue,
+        keyword,
+      },
+    ],
+    queryFn: ({ pageParam }) =>
+      fetchFn({
+        memberId,
+        lastFavoriteCount: pageParam.lastFavoriteCount,
+        lastSpaceId: pageParam.lastSpaceId,
+        pageSize: PAGE_SIZE,
+        sort: sortValue,
+        filter: categoryValue,
+        keyWord: keyword,
+      }),
+    initialPageParam: { lastSpaceId: undefined, lastFavoriteCount: undefined },
+    getNextPageParam: (
+      lastPage: MainSpacePageType,
+    ):
+      | {
+          lastSpaceId: number | undefined
+          lastFavoriteCount: number | undefined
+        }
+      | undefined => {
+      return lastPage.metaData?.hasNext
+        ? {
+            lastSpaceId: lastPage.metaData.lastId,
+            lastFavoriteCount: lastPage.metaData.lastFavoriteCount,
+          }
+        : undefined
+    },
+  })
+
+  return {
+    spaces: data,
+    fetchNextPage,
+    hasNextPage,
+    isSpacesLoading: isLoading,
+  }
+}
+
+export default useMainSpacesQuery

--- a/src/components/common/MainSpaceList/MainSpaceList.tsx
+++ b/src/components/common/MainSpaceList/MainSpaceList.tsx
@@ -46,7 +46,7 @@ const MainSpaceList = ({
     })
 
   const { target } = useInfiniteScroll({ hasNextPage, fetchNextPage })
-  console.log(spaces)
+
   return isSpacesLoading ? (
     <Spinner />
   ) : (

--- a/src/components/common/MainSpaceList/MainSpaceList.tsx
+++ b/src/components/common/MainSpaceList/MainSpaceList.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { Fragment } from 'react'
+import { NONE_SEARCH_RESULT } from '@/components/SpaceList/constants'
+import useMainSpacesQuery from '@/components/SpaceList/hooks/useMainSpacesQuery'
+import { CATEGORIES_RENDER } from '@/constants'
+import useInfiniteScroll from '@/hooks/useInfiniteScroll'
+import { SearchSpaceReqBody, SpaceResBody } from '@/types'
+import { Spinner } from '../..'
+import Space from '../Space/Space'
+
+export interface SpaceListProps {
+  memberId?: number
+  queryKey: string
+  sort?: string
+  category: string
+  keyword?: string
+  fetchFn: ({
+    memberId,
+    pageNumber,
+    lastFavoriteCount,
+    lastSpaceId,
+    pageSize,
+    sort,
+    filter,
+    keyWord,
+  }: SearchSpaceReqBody) => Promise<any>
+}
+
+const MainSpaceList = ({
+  queryKey,
+  memberId,
+  sort,
+  category,
+  keyword,
+  fetchFn,
+}: SpaceListProps) => {
+  const { spaces, fetchNextPage, hasNextPage, isSpacesLoading } =
+    useMainSpacesQuery({
+      queryKey,
+      memberId,
+      sort,
+      category,
+      keyword,
+      fetchFn,
+    })
+
+  const { target } = useInfiniteScroll({ hasNextPage, fetchNextPage })
+  console.log(spaces)
+  return isSpacesLoading ? (
+    <Spinner />
+  ) : (
+    <>
+      <ul className="flex flex-col gap-y-2 px-4 pt-2">
+        {spaces?.pages[0].responses.length
+          ? spaces?.pages.map((group, i) => (
+              <Fragment key={i}>
+                {group.responses?.map((space: SpaceResBody) => (
+                  <li key={space.spaceId}>
+                    <Space
+                      userName={space.ownerNickName}
+                      spaceId={space.spaceId}
+                      type="Card"
+                      spaceName={space.spaceName}
+                      spaceImage={space.spaceImagePath}
+                      description={space.description}
+                      category={CATEGORIES_RENDER[space.category]}
+                      scrap={space.scrapCount}
+                      favorite={space.favoriteCount}
+                    />
+                  </li>
+                ))}
+              </Fragment>
+            ))
+          : !isSpacesLoading && (
+              <div className="py-5 text-center text-sm font-medium text-gray9">
+                {NONE_SEARCH_RESULT}
+              </div>
+            )}
+
+        <div ref={target}></div>
+      </ul>
+    </>
+  )
+}
+
+export default MainSpaceList

--- a/src/services/space/spaces.ts
+++ b/src/services/space/spaces.ts
@@ -2,15 +2,19 @@ import { SearchSpaceReqBody, SpaceInviteResBody } from '@/types'
 import { apiClient } from '../apiServices'
 
 const fetchGetSpaces = async ({
-  pageNumber,
+  lastSpaceId,
+  lastFavoriteCount,
   pageSize,
   sort,
   filter,
 }: SearchSpaceReqBody) => {
   const path = '/api/spaces'
   const params = {
-    pageNumber: pageNumber.toString(),
     pageSize: pageSize.toString(),
+    ...(lastSpaceId !== undefined && { lastSpaceId: lastSpaceId.toString() }),
+    ...(lastFavoriteCount !== undefined && {
+      lastFavoriteCount: lastFavoriteCount.toString(),
+    }),
     ...(sort && { sort: sort }),
     filter: filter,
   }
@@ -25,7 +29,7 @@ const fetchGetSpaces = async ({
 }
 
 const fetchSearchSpaces = async ({
-  pageNumber,
+  pageNumber = 0,
   pageSize,
   sort,
   filter,
@@ -51,7 +55,7 @@ const fetchSearchSpaces = async ({
 
 const fetchSearchMySpaces = async ({
   memberId,
-  pageNumber,
+  pageNumber = 0,
   pageSize,
   filter,
   keyWord,

--- a/src/services/user/profile/favorites.ts
+++ b/src/services/user/profile/favorites.ts
@@ -2,7 +2,7 @@ import { apiClient } from '@/services/apiServices'
 import { SearchSpaceReqBody } from '@/types'
 
 const fetchGetMyFavoriteSpaces = async ({
-  pageNumber,
+  pageNumber = 0,
   pageSize,
   keyWord,
   filter,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -112,7 +112,9 @@ export interface UserDetailInfo {
 // 검색 req body
 export interface SearchSpaceReqBody {
   memberId?: number
-  pageNumber: number
+  pageNumber?: number
+  lastSpaceId?: number
+  lastFavoriteCount?: number
   pageSize: number
   sort?: string
   keyWord?: string


### PR DESCRIPTION
## 📑 이슈 번호
#289 
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 기존 `오프셋 기반 페이지네이션(Offset-based Pagination)`이 적용되었던 메인 페이지의 스페이스 리스트를 `커서 기반 페이지네이션(Cursor-based Pagination)` 방식으로 변경하였습니다.

- 메인 페이지, 검색 페이지, 프로필 페이지에서 스페이스 검색 로직이 공통적으로 사용되고 있어서 메인 페이지만 변경할 수 있도록 `useMainSpacesQuery` `MainSpaceList`를 추가로 구현하였습니다.

### 스페이스 필터 조회 API 변경점
기존 API request 값
```ts
{
  pageNumber: number,
  pageSize: number,
  sort: string,
  filter: string,
}
```

<br>

변경 후 API request 값
```ts
{
  lastFavoriteCount: number,
  lastSpaceId: number,
  pageSize: number,
  sort: string,
  filter: string,
}
```

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
Cursor-based Pagination 관련 글인데 궁금하시면 한 번 읽어봐도 좋을 것 같습니다!
[관련 블로그](https://velog.io/@minsangk/%EC%BB%A4%EC%84%9C-%EA%B8%B0%EB%B0%98-%ED%8E%98%EC%9D%B4%EC%A7%80%EB%84%A4%EC%9D%B4%EC%85%98-Cursor-based-Pagination-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0)