### PR TITLE
불필요하게 리렌더링되는 컴포넌트 메모이제이션

### DIFF
--- a/src/components/common/CategoryList/CategoryList.tsx
+++ b/src/components/common/CategoryList/CategoryList.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import 'swiper/css'
 import 'swiper/css/free-mode'
 import 'swiper/css/pagination'
@@ -66,4 +67,4 @@ const CategoryList = ({
   )
 }
 
-export default CategoryList
+export default React.memo(CategoryList)

--- a/src/components/common/CategoryList/CategoryListItem.tsx
+++ b/src/components/common/CategoryList/CategoryListItem.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import { cls } from '@/utils'
 import Link from 'next/link'
 import { usePathname, useSearchParams } from 'next/navigation'
@@ -63,4 +64,4 @@ const CategoryListItem = ({
   )
 }
 
-export default CategoryListItem
+export default React.memo(CategoryListItem)

--- a/src/components/common/Comment/Comment.tsx
+++ b/src/components/common/Comment/Comment.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import { useModal } from '@/hooks'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { getElapsedTime } from '@/utils'
@@ -162,4 +163,4 @@ const Comment = ({
   )
 }
 
-export default Comment
+export default React.memo(Comment)

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { cls } from '@/utils'
 import { LinkIcon } from '@heroicons/react/20/solid'
@@ -80,4 +81,4 @@ const Header = () => {
   )
 }
 
-export default Header
+export default React.memo(Header)

--- a/src/components/common/LinkItem/LinkItem.tsx
+++ b/src/components/common/LinkItem/LinkItem.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import { useForm } from 'react-hook-form'
 import TagInput from '@/components/TagInput/TagInput'
 import { useModal } from '@/hooks'
@@ -396,4 +397,4 @@ const LinkItem = ({
   )
 }
 
-export default LinkItem
+export default React.memo(LinkItem)

--- a/src/components/common/Space/Space.tsx
+++ b/src/components/common/Space/Space.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import React from 'react'
 import { useModal } from '@/hooks'
 import { useCurrentUser } from '@/hooks/useCurrentUser'
 import {
@@ -168,4 +169,4 @@ const Space = ({
   )
 }
 
-export default Space
+export default React.memo(Space)


### PR DESCRIPTION
## 📑 이슈 번호
#305 

## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
불필요하게 리렌더링되는 컴포넌트 메모이제이션하였습니다.

### 수정 전
![rerender1](https://github.com/Team-TenTen/LinkHub-FE/assets/66124037/db1a0c9d-48cb-4e12-b3cc-7955f7d2fdaa)

### 수정 후
![rerender2](https://github.com/Team-TenTen/LinkHub-FE/assets/66124037/e3c37304-e4a0-4e43-b19e-1354da532d99)


## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
### 메인 화면에서 부모컴포넌트의 state가 변경될때 마다 스페이스 리스트 컴포넌트의 불필요한 리렌더링이 과도하게 발생하여 컴포넌트 메모이제이션을 하였습니다.