### PR TITLE
Feature/#317/main css bug

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,58 +29,55 @@ export default function Home() {
     <>
       <section className="px-4 pb-8">
         <h2 className="py-4 font-bold text-gray9">인기있는 링크</h2>
-        {
-          links && (
-            <Swiper
-              slidesPerView={2.1}
-              breakpoints={{
-                640: {
-                  slidesPerView: 2.1,
-                },
-                768: {
-                  slidesPerView: 3.1,
-                },
-                1024: {
-                  slidesPerView: 4.1,
-                },
-                1280: {
-                  slidesPerView: 5.1,
-                },
-                1536: {
-                  slidesPerView: 6.1,
-                },
-                1920: {
-                  slidesPerView: 7.1,
-                },
-                2148: {
-                  slidesPerView: 8.1,
-                },
-                2324: {
-                  slidesPerView: 9.1,
-                },
-              }}
-              spaceBetween={16}
-              freeMode={true}
-              pagination={{
-                clickable: true,
-              }}
-              modules={[FreeMode]}
-              className="mySwiper">
-              {links.map((link: PopularLinkResBody) => (
-                <SwiperSlide key={link.linkId}>
-                  <LinkItem
-                    linkId={link.linkId}
-                    title={link.title}
-                    url={link.url}
-                    tagName={link.tagName}
-                    tagColor={link.tagColor as ChipColors}
-                    isInitLiked={link.isLiked}
-                    likeInitCount={link.likeCount}
-                    type="card"
-                  />
-                </SwiperSlide>
-              ))}
-            </Swiper>
+        {links && (
+          <Swiper
+            slidesPerView={2.2}
+            breakpoints={{
+              640: {
+                slidesPerView: 2.2,
+              },
+              743: {
+                slidesPerView: 3.2,
+              },
+              1099: {
+                slidesPerView: 4.2,
+              },
+              1455: {
+                slidesPerView: 5.2,
+              },
+              1811: {
+                slidesPerView: 6.2,
+              },
+              2152: {
+                slidesPerView: 7.2,
+              },
+
+              2324: {
+                slidesPerView: 8.2,
+              },
+            }}
+            spaceBetween={16}
+            freeMode={true}
+            pagination={{
+              clickable: true,
+            }}
+            modules={[FreeMode]}
+            className="mySwiper">
+            {links.map((link: PopularLinkResBody) => (
+              <SwiperSlide key={link.linkId}>
+                <LinkItem
+                  linkId={link.linkId}
+                  title={link.title}
+                  url={link.url}
+                  tagName={link.tagName}
+                  tagColor={link.tagColor as ChipColors}
+                  isInitLiked={link.isLiked}
+                  likeInitCount={link.likeCount}
+                  type="card"
+                />
+              </SwiperSlide>
+            ))}
+          </Swiper>
         )}
       </section>
       <section>

--- a/src/components/common/MainSpaceList/MainSpaceList.tsx
+++ b/src/components/common/MainSpaceList/MainSpaceList.tsx
@@ -58,7 +58,7 @@ const MainSpaceList = ({
     <>
       <ul
         className=" mb-4 grid gap-4 gap-y-2 px-4 pt-2"
-        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(400px, 1fr))' }}>
+        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(340px, 1fr))' }}>
         {spaces?.pages[0].responses.length
           ? spaces?.pages.map((group, i) => (
               <Fragment key={i}>


### PR DESCRIPTION
## 📑 이슈 번호
#317
## 🚧 구현 내용 <!--스크린샷은 UI 관련인 경우 꼭 넣기-->
- 모바일에서 메인 스페이스 리스트가 잘리는 현상 수정 
<img width="389" alt="스크린샷 2024-07-17 오후 10 40 47" src="https://github.com/user-attachments/assets/60e2dca4-859f-4c2d-8a9c-726e09de5068">

<br>
<br>

- 다음 링크가 더 잘 보일 수 있도록 slidesPerView 옵션 수정
<img width="483" alt="스크린샷 2024-07-17 오후 10 48 52" src="https://github.com/user-attachments/assets/461d7a0c-237e-423d-bdc4-03942225e4c4">

## 🚨 특이 사항 <!--특이 사항이나 리뷰어가 알고 있으면 좋을 것 같은 내용-->
